### PR TITLE
check if JNI use the same thread as Java

### DIFF
--- a/jni/com/jni/TestJni.java
+++ b/jni/com/jni/TestJni.java
@@ -54,15 +54,19 @@ public class TestJni {
             FunctionDescriptor.of(ValueLayout.JAVA_INT));
 
     // Java wrapper for calling gettid()
-    public static int gettid() throws Throwable {
-        return (int) GETTID.invokeExact();
+    public static int gettid() {
+        try {
+            return (int) GETTID.invokeExact();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public static void main(String[] args) throws Throwable {
+    public static void main(String[] args) {
 
         // Print thread ID info. Will compare with the info printed in C++ side.
-        System.out.println("JVM-level Thread ID: " + Thread.currentThread().getId());
-        System.out.println("OS-level Thread ID (report by Java): " + gettid());
+        System.out.println("JVM-level thread Id: " + Thread.currentThread().getId());
+        System.out.println("OS-level thread Id (report by Java): " + gettid());
 
         InputClass input = constructInput();
 

--- a/jni/jni.cc
+++ b/jni/jni.cc
@@ -214,19 +214,18 @@ JNIEXPORT jlong JNICALL Java_com_jni_JniMain_c_1constructCore
     return (jlong)(new Core());
 }
 
-
 JNIEXPORT jobject JNICALL Java_com_jni_JniMain_c_1process
   (JNIEnv * jenv, jobject, jlong jlong_corePtr, jobject jobj_input)
 {
     {
         // -------------------
         // I'm piggybacking this code to check if the thread Id in JNI is the same as that in Java or not
-        cout << "C++ level Thread ID: " << std::this_thread::get_id() << endl;
-        cout << "OS-level Thread ID (report by C++): " << gettid() << endl;
+        cout << "C++ level thread Id: " << std::this_thread::get_id() << endl;
+        cout << "OS-level thread ID (reported by C++): " << gettid() << endl;
 
         std::thread asyncThread([]() {
-            cout << "[Async function] C++ level Thread ID: " << std::this_thread::get_id() << endl;
-            cout << "[Async function] OS-level Thread ID (report by C++): " << gettid() << endl;
+            cout << "[Async function] C++ level thread Id: " << std::this_thread::get_id() << endl;
+            cout << "[Async function] OS-level thread ID (reported by C++): " << gettid() << endl;
         });
         asyncThread.join();
     }

--- a/jni/run_jni.sh
+++ b/jni/run_jni.sh
@@ -8,12 +8,12 @@ set -x
 # https://www.baeldung.com/jni
 
 export JAVA_HOME="/usr/lib/jvm/jre-24-openjdk" # Replace this by the correct path on your server
-#javac -h . com/jni/JniMain.java # It will generate a header file called com_jni_JniMain.h
+javac -h . com/jni/JniMain.java # It will generate a header file called com_jni_JniMain.h
 g++ -fPIC -std=c++14 -O3 -I"$JAVA_HOME/include" -I"$JAVA_HOME/include/linux" -shared -o libcore.so jni.cc
-#javac com/jni/JniMain.java
-#javac com/jni/OutputClass.java
-#javac com/jni/OutputClassInner.java
-#javac com/jni/InputClass.java
-#javac com/jni/InputClassInner.java
+javac com/jni/JniMain.java
+javac com/jni/OutputClass.java
+javac com/jni/OutputClassInner.java
+javac com/jni/InputClass.java
+javac com/jni/InputClassInner.java
 javac com/jni/TestJni.java
 java -Xmx16G -Djava.library.path=. -cp . com.jni.TestJni


### PR DESCRIPTION
the code prints
```
JVM-level thread Id: 3
OS-level thread Id (report by Java): 7967
C++ level thread Id: 140024165168704
OS-level thread ID (reported by C++): 7967
[Async function] C++ level thread Id: 140023077987904
[Async function] OS-level thread ID (reported by C++): 7985
```

so we can conclude that they indeed use the same thread