### PR TITLE
Add WorkerSplitLock and rename mutexes to reflect protected resources

### DIFF
--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -114,16 +114,14 @@ The pseudo-code below shows the locking structure of each worker. Operations out
 ```
 score()
 {
-    lock(globalMutex)
-    {
+    { lock(globalMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    lock(globalMutex)
-    {
+    { lock(globalMutex)
         resolveMap()
         H2D()
         embScatterKernel()
@@ -132,8 +130,7 @@ upsert()
 
 updateScalar()
 {
-    lock(globalMutex)
-    {
+    { lock(globalMutex)
         resolveMap()
         H2D()
         scalarScatterKernel()
@@ -142,8 +139,7 @@ updateScalar()
 
 delete()
 {
-    lock(globalMutex)
-    {
+    { lock(globalMutex)
         resolveMap()
         H2D()
         setDirtyKernel()
@@ -156,47 +152,40 @@ delete()
 ```
 score()
 {
-    lock(embDataMutex, scalarMutex, dirtyBitMutex)
-    {
+    { lock(embDataMutex, scalarMutex, dirtyBitMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(embDataMutex)
-    {
+    { lock(embDataMutex)
         embScatterKernel()
     }
 }
 
 updateScalar()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(scalarMutex)
-    {
+    { lock(scalarMutex)
         scalarScatterKernel()
     }
 }
 
 delete()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirtyKernel()
     }
 }
@@ -207,57 +196,48 @@ delete()
 ```
 score()
 {
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirty(DIRTY)
     }
     embScatterKernel()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirty(CLEAN)
     }
 }
 
 updateScalar()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirty(DIRTY)
     }
     scalarScatterKernel()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirty(CLEAN)
     }
 }
 
 delete()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
     }
     H2D()
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         setDirtyKernel(DIRTY)
     }
 }
@@ -268,24 +248,21 @@ delete()
 ```
 score()
 {
-    lock(dirtyBitMutex, scalarMutex)
-    {
+    { lock(dirtyBitMutex, scalarMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
         H2D()
         embScatterKernel()
         carryScalarsH2D()
         scalarScatterKernel()
     }
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
@@ -294,13 +271,11 @@ upsert()
 
 updateScalar()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
         updateCPUScalars()
         H2D()
-        lock(scalarMutex)
-        {
+        { lock(scalarMutex)
             scalarScatterKernel()
         }
     }
@@ -308,13 +283,11 @@ updateScalar()
 
 delete()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
         eraseCPUScalars()
         H2D()
-        lock(dirtyBitMutex)
-        {
+        { lock(dirtyBitMutex)
             setDirtyKernel(DIRTY)
         }
     }
@@ -326,12 +299,10 @@ delete()
 ```
 score()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         snapshotScalarsFromCPU()
     }
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         H2D()
         scalarScatterKernel()
         scoreKernel()
@@ -340,14 +311,12 @@ score()
 
 upsert()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
         H2D()
         embScatterKernel()
     }
-    lock(dirtyBitMutex)
-    {
+    { lock(dirtyBitMutex)
         H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
@@ -356,21 +325,18 @@ upsert()
 
 updateScalar()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         updateCPUScalarsOnly()
     }
 }
 
 delete()
 {
-    lock(mapMutex)
-    {
+    { lock(mapMutex)
         resolveMap()
         eraseCPUScalars()
         H2D()
-        lock(dirtyBitMutex)
-        {
+        { lock(dirtyBitMutex)
             setDirtyKernel(DIRTY)
         }
     }

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -252,49 +252,57 @@ Score: 3000 calls/sec (10k rows each). Upsert: 70k docs/sec. UpdateScalar: 30k d
 ```
 === WorkerNaive ===
   headRowIdx: 1000000 -> 1000500
-  score             calls=31141                     mean=0.482ms       p50=0.288ms       p99=5.047ms
-  upsert            calls=1044    docs=1044000     mean=14.032ms      p50=13.433ms      p99=16.136ms
-  delete            calls=1044    docs=522000      mean=0.077ms       p50=0.074ms       p99=0.115ms
-  updateScalar      calls=451     docs=451000      mean=2.347ms       p50=1.498ms       p99=6.150ms
-  observed QPS (calls):  score=2076.1
-  observed doc QPS:  upsert=69600.0  delete=34800.0  updateScalar=30066.7
+  score             calls=13492                     mean=1.111ms       p50=0.972ms       p99=5.420ms
+  upsert            calls=285     docs=285000      mean=52.699ms      p50=50.327ms      p99=60.298ms
+  delete            calls=285     docs=142500      mean=0.082ms       p50=0.072ms       p99=0.129ms
+  updateScalar      calls=451     docs=451000      mean=4.416ms       p50=4.344ms       p99=8.830ms
+  observed QPS (calls):  score=899.5
+  observed doc QPS:  upsert=19000.0  delete=9500.0  updateScalar=30066.7
+
+=== WorkerSplitLock ===
+  headRowIdx: 1000000 -> 1000500
+  score             calls=15843                     mean=0.946ms       p50=0.899ms       p99=1.797ms
+  upsert            calls=294     docs=294000      mean=51.157ms      p50=49.752ms      p99=61.319ms
+  delete            calls=294     docs=147000      mean=0.124ms       p50=0.071ms       p99=0.692ms
+  updateScalar      calls=451     docs=451000      mean=4.560ms       p50=4.438ms       p99=7.953ms
+  observed QPS (calls):  score=1056.2
+  observed doc QPS:  upsert=19600.0  delete=9800.0  updateScalar=30066.7
 
 === WorkerOverwrite ===
   headRowIdx: 1000000 -> 1000500
-  score             calls=44791                     mean=0.333ms       p50=0.288ms       p99=1.386ms
-  upsert            calls=1047    docs=1047000     mean=14.156ms      p50=13.691ms      p99=16.849ms
-  delete            calls=1047    docs=523500      mean=0.305ms       p50=0.268ms       p99=0.621ms
-  updateScalar      calls=451     docs=451000      mean=2.546ms       p50=1.844ms       p99=5.884ms
-  observed QPS (calls):  score=2986.1
-  observed doc QPS:  upsert=69800.0  delete=34900.0  updateScalar=30066.7
+  score             calls=16198                     mean=0.926ms       p50=0.897ms       p99=1.755ms
+  upsert            calls=299     docs=299000      mean=50.288ms      p50=49.835ms      p99=60.621ms
+  delete            calls=299     docs=149500      mean=0.116ms       p50=0.066ms       p99=0.686ms
+  updateScalar      calls=451     docs=451000      mean=4.823ms       p50=4.632ms       p99=8.066ms
+  observed QPS (calls):  score=1079.9
+  observed doc QPS:  upsert=19933.3  delete=9966.7  updateScalar=30066.7
 
 === WorkerCopyOnWriteEager ===
   headRowIdx: 1000000 -> 1000500
-  score             calls=43735                     mean=0.342ms       p50=0.291ms       p99=1.436ms
-  upsert            calls=957     docs=957000      mean=15.679ms      p50=15.222ms      p99=19.359ms
-  delete            calls=957     docs=478500      mean=0.537ms       p50=0.272ms       p99=1.888ms
-  updateScalar      calls=451     docs=451000      mean=3.203ms       p50=2.141ms       p99=7.863ms
-  observed QPS (calls):  score=2915.7
-  observed doc QPS:  upsert=63800.0  delete=31900.0  updateScalar=30066.7
+  score             calls=15170                     mean=0.988ms       p50=0.933ms       p99=1.885ms
+  upsert            calls=276     docs=276000      mean=54.382ms      p50=51.743ms      p99=64.133ms
+  delete            calls=276     docs=138000      mean=0.373ms       p50=0.107ms       p99=2.098ms
+  updateScalar      calls=451     docs=451000      mean=4.986ms       p50=4.866ms       p99=9.912ms
+  observed QPS (calls):  score=1011.3
+  observed doc QPS:  upsert=18400.0  delete=9200.0  updateScalar=30066.7
 
 === WorkerCopyOnWriteLazy ===
   headRowIdx: 1000000 -> 1000500
-  score             calls=1539                      mean=9.747ms       p50=8.820ms       p99=14.401ms
-  upsert            calls=556     docs=556000      mean=26.982ms      p50=27.775ms      p99=31.052ms
-  delete            calls=556     docs=278000      mean=8.369ms       p50=8.278ms       p99=10.791ms
-  updateScalar      calls=451     docs=451000      mean=6.086ms       p50=6.232ms       p99=13.045ms
-  observed QPS (calls):  score=102.6
-  observed doc QPS:  upsert=37066.7  delete=18533.3  updateScalar=30066.7
+  score             calls=1552                      mean=9.666ms       p50=9.140ms       p99=14.321ms
+  upsert            calls=241     docs=241000      mean=62.427ms      p50=61.799ms      p99=73.911ms
+  delete            calls=241     docs=120500      mean=8.550ms       p50=8.513ms       p99=11.318ms
+  updateScalar      calls=451     docs=451000      mean=7.302ms       p50=6.973ms       p99=14.604ms
+  observed QPS (calls):  score=103.5
+  observed doc QPS:  upsert=16066.7  delete=8033.3  updateScalar=30066.7
 ```
-
-> WorkerSplitLock results not yet available — benchmark will be updated after a full run.
 
 **Key observations:**
 
-- **WorkerNaive** hits a score bottleneck: the global mutex means upserts (14ms each) block score threads, limiting score to 2076 calls/sec vs the 3000 target.
-- **WorkerOverwrite** reaches near-full score throughput (2986/sec) by using two separate mutexes — score and upsert can now overlap. Upsert latency is similar to Naive since it still writes in-place with dirty-bit fencing.
-- **WorkerCopyOnWriteEager** also reaches near-full score throughput (2916/sec). Upsert is slightly slower than Overwrite (~16ms vs ~14ms) because it must carry scalars to the new rowIdx before flipping the dirty bit. UpdateScalar is also slightly slower (~3.2ms vs ~2.5ms) due to holding `m_scalarMutex` during the scatter to prevent scorers from reading mid-write.
-- **WorkerCopyOnWriteLazy** suffers severely: `score` holds `m_mapMutex` to walk `rowIdx → docId → scalar` for all 10k target rows, H2D-syncs the result, then scores — driving score latency to ~10ms and throughput to only 103 calls/sec, 29x slower than Overwrite/COWEager. Upsert and delete are slower too because they contend with score on `m_mapMutex`.
+- **WorkerNaive** hits a score bottleneck: the global mutex means upserts (~53ms each) block score threads, limiting score to 900 calls/sec vs the 3000 target.
+- **WorkerSplitLock** improves score throughput to 1056/sec — better than Naive since score no longer blocks during map resolution or H2D. However, score still blocks during scatter kernels (no dirty bits), so throughput is similar to WorkerOverwrite rather than dramatically better.
+- **WorkerOverwrite** reaches 1080/sec, slightly ahead of SplitLock. Dirty bits allow the score kernel and emb scatter to overlap on different rows, whereas SplitLock blocks score for the entire scatter duration.
+- **WorkerCopyOnWriteEager** scores at 1011/sec, slightly behind Overwrite. Upsert is slower (~54ms vs ~50ms) because it must carry scalars to the new rowIdx before flipping the dirty bit.
+- **WorkerCopyOnWriteLazy** suffers severely: `score` holds `m_mapMutex` to walk `rowIdx → docId → scalar` for all 10k target rows, H2D-syncs the result, then scores — driving score latency to ~10ms and throughput to only 104 calls/sec, ~10x slower than the others. Upsert and delete are slower too because they contend with score on `m_mapMutex`.
 
 ## Build
 

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -297,11 +297,11 @@ updateScalar()
     {
         resolveMap()
         updateCPUScalars()
-    }
-    H2D()
-    lock(scalarMutex)
-    {
-        scalarScatterKernel()
+        H2D()
+        lock(scalarMutex)
+        {
+            scalarScatterKernel()
+        }
     }
 }
 
@@ -311,11 +311,11 @@ delete()
     {
         resolveMap()
         eraseCPUScalars()
-    }
-    H2D()
-    lock(dirtyBitMutex)
-    {
-        setDirtyKernel(DIRTY)
+        H2D()
+        lock(dirtyBitMutex)
+        {
+            setDirtyKernel(DIRTY)
+        }
     }
 }
 ```
@@ -366,11 +366,11 @@ delete()
     {
         resolveMap()
         eraseCPUScalars()
-    }
-    H2D()
-    lock(dirtyBitMutex)
-    {
-        setDirtyKernel(DIRTY)
+        H2D()
+        lock(dirtyBitMutex)
+        {
+            setDirtyKernel(DIRTY)
+        }
     }
 }
 ```

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -112,92 +112,267 @@ The pseudo-code below shows the locking structure of each worker. Operations out
 ### WorkerNaive
 
 ```
-score()        { lock(globalMutex) { scoreKernel } }
+score()
+{
+    lock(globalMutex)
+    {
+        scoreKernel()
+    }
+}
 
-upsert()       { lock(globalMutex) { resolveMap; H2D; embScatterKernel } }
+upsert()
+{
+    lock(globalMutex)
+    {
+        resolveMap()
+        H2D()
+        embScatterKernel()
+    }
+}
 
-updateScalar() { lock(globalMutex) { resolveMap; H2D; scalarScatterKernel } }
+updateScalar()
+{
+    lock(globalMutex)
+    {
+        resolveMap()
+        H2D()
+        scalarScatterKernel()
+    }
+}
 
-delete()       { lock(globalMutex) { resolveMap; H2D; setDirtyKernel } }
+delete()
+{
+    lock(globalMutex)
+    {
+        resolveMap()
+        H2D()
+        setDirtyKernel()
+    }
+}
 ```
 
 ### WorkerSplitLock
 
 ```
-score()        { lock(embDataMutex, scalarMutex, dirtyBitMutex) { scoreKernel } }
+score()
+{
+    lock(embDataMutex, scalarMutex, dirtyBitMutex)
+    {
+        scoreKernel()
+    }
+}
 
-upsert()       { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(embDataMutex) { embScatterKernel } }
+upsert()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(embDataMutex)
+    {
+        embScatterKernel()
+    }
+}
 
-updateScalar() { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(scalarMutex) { scalarScatterKernel } }
+updateScalar()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(scalarMutex)
+    {
+        scalarScatterKernel()
+    }
+}
 
-delete()       { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(dirtyBitMutex) { setDirtyKernel } }
+delete()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirtyKernel()
+    }
+}
 ```
 
 ### WorkerOverwrite
 
 ```
-score()        { lock(dirtyBitMutex) { scoreKernel } }
+score()
+{
+    lock(dirtyBitMutex)
+    {
+        scoreKernel()
+    }
+}
 
-upsert()       { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(dirtyBitMutex) { setDirty(DIRTY) }
-                 embScatterKernel
-                 lock(dirtyBitMutex) { setDirty(CLEAN) } }
+upsert()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirty(DIRTY)
+    }
+    embScatterKernel()
+    lock(dirtyBitMutex)
+    {
+        setDirty(CLEAN)
+    }
+}
 
-updateScalar() { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(dirtyBitMutex) { setDirty(DIRTY) }
-                 scalarScatterKernel
-                 lock(dirtyBitMutex) { setDirty(CLEAN) } }
+updateScalar()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirty(DIRTY)
+    }
+    scalarScatterKernel()
+    lock(dirtyBitMutex)
+    {
+        setDirty(CLEAN)
+    }
+}
 
-delete()       { lock(mapMutex) { resolveMap }
-                 H2D
-                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+delete()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirtyKernel(DIRTY)
+    }
+}
 ```
 
 ### WorkerCopyOnWriteEager
 
 ```
-score()        { lock(dirtyBitMutex, scalarMutex) { scoreKernel } }
+score()
+{
+    lock(dirtyBitMutex, scalarMutex)
+    {
+        scoreKernel()
+    }
+}
 
-upsert()       { lock(mapMutex) { resolveMap
-                                  H2D
-                                  embScatterKernel
-                                  carryScalarsH2D
-                                  scalarScatterKernel }
-                 lock(dirtyBitMutex) { setDirty(old=DIRTY)
-                                       setDirty(new=CLEAN) } }
+upsert()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+        H2D()
+        embScatterKernel()
+        carryScalarsH2D()
+        scalarScatterKernel()
+    }
+    lock(dirtyBitMutex)
+    {
+        setDirty(old=DIRTY)
+        setDirty(new=CLEAN)
+    }
+}
 
-updateScalar() { lock(mapMutex) { resolveMap; updateCPUScalars }
-                 H2D
-                 lock(scalarMutex) { scalarScatterKernel } }
+updateScalar()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+        updateCPUScalars()
+    }
+    H2D()
+    lock(scalarMutex)
+    {
+        scalarScatterKernel()
+    }
+}
 
-delete()       { lock(mapMutex) { resolveMap; eraseCPUScalars }
-                 H2D
-                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+delete()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+        eraseCPUScalars()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirtyKernel(DIRTY)
+    }
+}
 ```
 
 ### WorkerCopyOnWriteLazy
 
 ```
-score()        { lock(mapMutex) { snapshotScalarsFromCPU }
-                 lock(dirtyBitMutex) { H2D; scalarScatterKernel; scoreKernel } }
+score()
+{
+    lock(mapMutex)
+    {
+        snapshotScalarsFromCPU()
+    }
+    lock(dirtyBitMutex)
+    {
+        H2D()
+        scalarScatterKernel()
+        scoreKernel()
+    }
+}
 
-upsert()       { lock(mapMutex) { resolveMap; H2D; embScatterKernel }
-                 lock(dirtyBitMutex) { setDirty(old=DIRTY)
-                                       setDirty(new=CLEAN) } }
+upsert()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+        H2D()
+        embScatterKernel()
+    }
+    lock(dirtyBitMutex)
+    {
+        setDirty(old=DIRTY)
+        setDirty(new=CLEAN)
+    }
+}
 
-updateScalar() { lock(mapMutex) { updateCPUScalarsOnly } }
+updateScalar()
+{
+    lock(mapMutex)
+    {
+        updateCPUScalarsOnly()
+    }
+}
 
-delete()       { lock(mapMutex) { resolveMap; eraseCPUScalars }
-                 H2D
-                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+delete()
+{
+    lock(mapMutex)
+    {
+        resolveMap()
+        eraseCPUScalars()
+    }
+    H2D()
+    lock(dirtyBitMutex)
+    {
+        setDirtyKernel(DIRTY)
+    }
+}
 ```
 
 ## Strategy Analysis

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -286,6 +286,7 @@ upsert()
     }
     lock(dirtyBitMutex)
     {
+        H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
     }
@@ -347,6 +348,7 @@ upsert()
     }
     lock(dirtyBitMutex)
     {
+        H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
     }

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -1,6 +1,6 @@
 # Concurrent Read / Write Design Paradigm
 
-Benchmarks four concurrent read/write strategies for a GPU vector index under mixed workloads: simultaneous scoring (reads) and upsert/delete/scalar-update (writes).
+Benchmarks five concurrent read/write strategies for a GPU vector index under mixed workloads: simultaneous scoring (reads) and upsert/delete/scalar-update (writes).
 
 ## Motivation
 
@@ -52,17 +52,27 @@ Getting concurrent reads and writes correct requires navigating four tensions:
 
 4. **docId↔rowIdx map mutation** — Some strategies (copy-on-write) allocate a new rowIdx on every upsert and free the old one. This keeps the embedding write invisible until committed, but it means the map is constantly changing, which adds overhead and complexity.
 
-## The Four Strategies
+## The Five Strategies
 
 ### WorkerNaive
 
 One global mutex serializes all operations (upserts, deletes, scalar updates, and scoring). Simple and correct but every operation blocks every other.
 
+### WorkerSplitLock
+
+Uses four fine-grained mutexes — one per protected resource — with no dirty bits:
+- `m_mapMutex`: protects the CPU `docId → rowIdx` map during resolution
+- `m_embDataMutex`: serializes GPU embedding scatter vs. score kernel
+- `m_scalarMutex`: serializes GPU scalar scatter vs. score kernel
+- `m_dirtyBitMutex`: serializes GPU dirty-bit writes vs. score kernel
+
+H2D transfers happen outside all locks. Each writer holds only the mutex for its own GPU resource, so upsert, updateScalar, and delete can run concurrently with each other. Score holds all three GPU mutexes simultaneously via `std::scoped_lock`. Because there are no dirty bits, score blocks for the full duration of any concurrent scatter kernel on its resource.
+
 ### WorkerOverwrite
 
-Splits locking into two mutexes:
-- `m_writeMutex`: protects the `docId -> rowIdx` map during resolution
-- `m_readMutex`: protects dirty bits during score reads
+Uses two mutexes:
+- `m_mapMutex`: protects the `docId → rowIdx` map during resolution
+- `m_dirtyBitMutex`: protects dirty bits during score reads
 
 Upsert writes in-place to the existing rowIdx. To prevent a scorer from reading a half-written embedding, the dirty bit is set to 1 before the scatter and cleared to 0 after. This means score and upsert can overlap — the scorer sees the row as dirty and skips it — but two concurrent upserts to the same row are still safe because the dirty bit prevents the scorer from seeing a torn write.
 
@@ -70,49 +80,157 @@ Upsert writes in-place to the existing rowIdx. To prevent a scorer from reading 
 
 ### WorkerCopyOnWriteEager
 
+Uses three mutexes:
+- `m_mapMutex`: protects the `docId → rowIdx` map and CPU scalar mirror
+- `m_dirtyBitMutex`: protects dirty-bit flips vs. score kernel
+- `m_scalarMutex`: protects GPU scalar scatter vs. score kernel
+
 Instead of overwriting the existing row, upsert always allocates a **new** rowIdx for the document, scatters the new embedding there, then atomically flips dirty bits: mark the old row dirty (hidden) and mark the new row clean (visible).
 
-This means the scorer never sees a partially-written embedding — either it reads the old clean row or the new clean row, never a half-written one. The flip is the only moment that requires holding `m_readMutex`.
+This means the scorer never sees a partially-written embedding — either it reads the old clean row or the new clean row, never a half-written one. The flip is the only moment that requires holding `m_dirtyBitMutex`.
 
-Scalar data is kept both on CPU (in `m_docId2scalar`) and on GPU (`m_d_scalars`). `updateScalarData` scatters scalars to GPU immediately. `upsertDocs` carries the CPU-side scalars to the new rowIdx between the emb scatter and the dirty-bit flip, so the new row has up-to-date scalar values when it becomes visible.
+Scalar data is kept both on CPU (in `m_docId2scalar`) and on GPU (`m_d_scalars`). `updateScalarData` scatters scalars to GPU immediately under `m_scalarMutex`. `upsertDocs` carries the CPU-side scalars to the new rowIdx between the emb scatter and the dirty-bit flip, so the new row has up-to-date scalar values when it becomes visible.
 
 ### WorkerCopyOnWriteLazy
+
+Uses two mutexes:
+- `m_mapMutex`: protects the `docId → rowIdx` map and CPU scalar mirror
+- `m_dirtyBitMutex`: protects dirty-bit flips vs. score kernel
 
 Same copy-on-write approach for embeddings. The difference is in how scalars are handled:
 
 - `updateScalarData` stores scalars on CPU only — no GPU scatter at all.
 - `upsertDocs` does not touch scalars; the new row's scalar slot in `m_d_scalars` is intentionally left stale.
-- `score` first snapshots the CPU scalar maps under `m_writeMutex` (resolving `rowIdx → docId → scalar` for each target row), then H2D-syncs the snapshot to GPU and runs the score kernel under `m_readMutex`.
+- `score` first snapshots the CPU scalar maps under `m_mapMutex` (resolving `rowIdx → docId → scalar` for each target row), then H2D-syncs the snapshot to GPU and runs the score kernel under `m_dirtyBitMutex`.
 
-This eliminates the scalar-carry step from the hot upsert path, but pushes significant cost into every score call: a CPU map walk under `m_writeMutex` plus an H2D transfer before each score kernel.
+This eliminates the scalar-carry step from the hot upsert path, but pushes significant cost into every score call: a CPU map walk under `m_mapMutex` plus an H2D transfer before each score kernel.
+
+## Locking Schemes
+
+The pseudo-code below shows the locking structure of each worker. Operations outside any lock block can run concurrently with other threads.
+
+### WorkerNaive
+
+```
+score()        { lock(globalMutex) { scoreKernel } }
+
+upsert()       { lock(globalMutex) { resolveMap; H2D; embScatterKernel } }
+
+updateScalar() { lock(globalMutex) { resolveMap; H2D; scalarScatterKernel } }
+
+delete()       { lock(globalMutex) { resolveMap; H2D; setDirtyKernel } }
+```
+
+### WorkerSplitLock
+
+```
+score()        { lock(embDataMutex, scalarMutex, dirtyBitMutex) { scoreKernel } }
+
+upsert()       { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(embDataMutex) { embScatterKernel } }
+
+updateScalar() { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(scalarMutex) { scalarScatterKernel } }
+
+delete()       { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(dirtyBitMutex) { setDirtyKernel } }
+```
+
+### WorkerOverwrite
+
+```
+score()        { lock(dirtyBitMutex) { scoreKernel } }
+
+upsert()       { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(dirtyBitMutex) { setDirty(DIRTY) }
+                 embScatterKernel
+                 lock(dirtyBitMutex) { setDirty(CLEAN) } }
+
+updateScalar() { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(dirtyBitMutex) { setDirty(DIRTY) }
+                 scalarScatterKernel
+                 lock(dirtyBitMutex) { setDirty(CLEAN) } }
+
+delete()       { lock(mapMutex) { resolveMap }
+                 H2D
+                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+```
+
+### WorkerCopyOnWriteEager
+
+```
+score()        { lock(dirtyBitMutex, scalarMutex) { scoreKernel } }
+
+upsert()       { lock(mapMutex) { resolveMap
+                                  H2D
+                                  embScatterKernel
+                                  carryScalarsH2D
+                                  scalarScatterKernel }
+                 lock(dirtyBitMutex) { setDirty(old=DIRTY)
+                                       setDirty(new=CLEAN) } }
+
+updateScalar() { lock(mapMutex) { resolveMap; updateCPUScalars }
+                 H2D
+                 lock(scalarMutex) { scalarScatterKernel } }
+
+delete()       { lock(mapMutex) { resolveMap; eraseCPUScalars }
+                 H2D
+                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+```
+
+### WorkerCopyOnWriteLazy
+
+```
+score()        { lock(mapMutex) { snapshotScalarsFromCPU }
+                 lock(dirtyBitMutex) { H2D; scalarScatterKernel; scoreKernel } }
+
+upsert()       { lock(mapMutex) { resolveMap; H2D; embScatterKernel }
+                 lock(dirtyBitMutex) { setDirty(old=DIRTY)
+                                       setDirty(new=CLEAN) } }
+
+updateScalar() { lock(mapMutex) { updateCPUScalarsOnly } }
+
+delete()       { lock(mapMutex) { resolveMap; eraseCPUScalars }
+                 H2D
+                 lock(dirtyBitMutex) { setDirtyKernel(DIRTY) } }
+```
 
 ## Strategy Analysis
 
 | | Race condition | Concurrency | Doc visibility | Carry secondary on upsert | Map lookup in score |
 |---|---|---|---|---|---|
 | Naive | ✅ (global mutex) | ❌ fully serialized | ✅ no (never dirty) | ✅ no | ✅ no |
+| SplitLock | ✅ (per-resource mutex) | ✅ writers overlap each other; score blocks per-resource | ✅ no (never dirty) | ✅ no | ✅ no |
 | Overwrite | ✅ (dirty-bit fence) | ✅ score overlaps write | ❌ dirty during emb+scalar scatter | ✅ no | ✅ no |
-| COW Eager | ✅ (new rowIdx + readMutex for scalars) | ✅ score overlaps emb write | ✅ old row visible until flip | ❌ yes (scalars copied to new rowIdx before flip) | ✅ no |
+| COW Eager | ✅ (new rowIdx + m_scalarMutex for scalars) | ✅ score overlaps emb write | ✅ old row visible until flip | ❌ yes (scalars copied to new rowIdx before flip) | ✅ no |
 | COW Lazy | ✅ (new rowIdx) | ⚠️ score serializes on scalar sync | ✅ old row visible until flip | ✅ no (scalars always synced from CPU in score) | ❌ yes (rowIdx→docId→scalar per target row) |
+
+**WorkerSplitLock** gives each GPU resource its own mutex, allowing writers to run concurrently with each other. Score still blocks during any scatter kernel touching its resources — there are no dirty bits to allow overlap. It is a strict improvement over Naive for multi-writer workloads.
 
 **WorkerOverwrite** handles races well and keeps the map stable, but the dirty-bit fence during both primary (emb) and secondary (scalar) updates makes documents transiently invisible to scorers.
 
-**WorkerCopyOnWriteEager** eliminates the visibility problem for primary updates by writing to a fresh rowIdx and flipping atomically. For secondary (scalar) updates, it avoids dirty-bit fencing entirely — the document stays visible — but must hold `m_readMutex` during the scatter to prevent scorers from reading mid-write. The tradeoff is constant map churn: every primary upsert allocates a new rowIdx and frees the old one.
+**WorkerCopyOnWriteEager** eliminates the visibility problem for primary updates by writing to a fresh rowIdx and flipping atomically. For secondary (scalar) updates, it avoids dirty-bit fencing entirely — the document stays visible — but must hold `m_scalarMutex` during the scatter to prevent scorers from reading mid-write. The tradeoff is constant map churn: every primary upsert allocates a new rowIdx and frees the old one.
 
-**WorkerCopyOnWriteLazy** avoids the scalar-carry step on the upsert path by keeping scalars on CPU only. But this pushes the cost into every score call: `score` must hold `m_writeMutex` to walk `rowIdx → docId → scalar` for each of the 10k target rows, build a scatter buffer, H2D-sync it, and only then run the score kernel. This map lookup and transfer on the hot scoring path is the dominant bottleneck — it drives score latency from ~0.3ms to ~10ms and limits throughput to ~103 calls/sec. Upsert and delete are also slower because they contend with score on `m_writeMutex`.
+**WorkerCopyOnWriteLazy** avoids the scalar-carry step on the upsert path by keeping scalars on CPU only. But this pushes the cost into every score call: `score` must hold `m_mapMutex` to walk `rowIdx → docId → scalar` for each of the 10k target rows, build a scatter buffer, H2D-sync it, and only then run the score kernel. This map lookup and transfer on the hot scoring path is the dominant bottleneck — it drives score latency from ~0.3ms to ~10ms and limits throughput to ~103 calls/sec. Upsert and delete are also slower because they contend with score on `m_mapMutex`.
 
 ## Concurrency Summary
 
-| Worker | Upsert vs Score | Upsert vs Upsert | Scalar update vs Score |
-|---|---|---|---|
-| Naive | Serialized | Serialized | Serialized |
-| Overwrite | Overlapping (dirty bit) | **Races** on m_writeStream | Overlapping (dirty bit) |
-| COW Eager | Overlapping (new rowIdx) | Serialized (m_writeMutex) | Serialized (m_readMutex, no dirty-bit fencing) |
-| COW Lazy | Overlapping (new rowIdx) | Serialized (m_writeMutex) | Score syncs CPU→GPU per call |
+| Worker | Upsert vs Score | Upsert vs Upsert | Scalar update vs Score | Upsert vs Scalar update |
+|---|---|---|---|---|
+| Naive | Serialized | Serialized | Serialized | Serialized |
+| SplitLock | Overlapping (different GPU mutexes) | Serialized (m_mapMutex) | Overlapping (different GPU mutexes) | ✅ fully overlapping |
+| Overwrite | Overlapping (dirty bit) | **Races** on m_writeStream | Overlapping (dirty bit) | ⚠️ races on m_writeStream |
+| COW Eager | Overlapping (new rowIdx) | Serialized (m_mapMutex) | Serialized (m_scalarMutex, no dirty-bit fencing) | Serialized (m_mapMutex) |
+| COW Lazy | Overlapping (new rowIdx) | Serialized (m_mapMutex) | Score syncs CPU→GPU per call | ✅ fully overlapping |
 
-> **Note on Upsert vs Upsert:** The benchmark uses a single upsert thread, so concurrent upserts never occur in practice. WorkerOverwrite would race if two upsert threads overlapped in the GPU scatter phase, since `m_writeMutex` is released before GPU work. COW workers serialize the entire write operation under `m_writeMutex` (including GPU work), so concurrent upserts are safe — but only because of the mutex, not because of rowIdx isolation.
+> **Note on Upsert vs Upsert:** The benchmark uses a single upsert thread, so concurrent upserts never occur in practice. WorkerOverwrite would race if two upsert threads overlapped in the GPU scatter phase, since `m_mapMutex` is released before GPU work. COW workers serialize the entire write operation under `m_mapMutex` (including GPU work), so concurrent upserts are safe — but only because of the mutex, not because of rowIdx isolation.
 >
-> **Note on Upsert vs UpdateScalar in WorkerOverwrite:** Both operations release `m_writeMutex` before GPU work, so the upsert thread and the updateScalar thread (which ARE concurrent in the benchmark) can both issue to `m_writeStream` simultaneously. The dirty-bit kernels are serialized by `m_readMutex`, but the H2D and scatter phases between them are not. If the two operations happen to target the same doc, one thread's `kn_setDirty(CLEAN)` could overwrite the other's `kn_setDirty(DIRTY)` before the scatter completes, briefly exposing a partially-written row. Fixing this would require a dedicated stream mutex or extending `m_writeMutex` to cover all GPU work.
+> **Note on Upsert vs UpdateScalar in WorkerOverwrite:** Both operations release `m_mapMutex` before GPU work, so the upsert thread and the updateScalar thread (which ARE concurrent in the benchmark) can both issue to `m_writeStream` simultaneously. The dirty-bit kernels are serialized by `m_dirtyBitMutex`, but the H2D and scatter phases between them are not. If the two operations happen to target the same doc, one thread's `kn_setDirty(CLEAN)` could overwrite the other's `kn_setDirty(DIRTY)` before the scatter completes, briefly exposing a partially-written row. Fixing this would require a dedicated stream mutex or extending `m_mapMutex` to cover all GPU work.
 
 ## Benchmark
 
@@ -169,12 +287,14 @@ Score: 3000 calls/sec (10k rows each). Upsert: 70k docs/sec. UpdateScalar: 30k d
   observed doc QPS:  upsert=37066.7  delete=18533.3  updateScalar=30066.7
 ```
 
+> WorkerSplitLock results not yet available — benchmark will be updated after a full run.
+
 **Key observations:**
 
 - **WorkerNaive** hits a score bottleneck: the global mutex means upserts (14ms each) block score threads, limiting score to 2076 calls/sec vs the 3000 target.
 - **WorkerOverwrite** reaches near-full score throughput (2986/sec) by using two separate mutexes — score and upsert can now overlap. Upsert latency is similar to Naive since it still writes in-place with dirty-bit fencing.
-- **WorkerCopyOnWriteEager** also reaches near-full score throughput (2916/sec). Upsert is slightly slower than Overwrite (~16ms vs ~14ms) because it must carry scalars to the new rowIdx before flipping the dirty bit. UpdateScalar is also slightly slower (~3.2ms vs ~2.5ms) due to holding `m_readMutex` during the scatter to prevent scorers from reading mid-write.
-- **WorkerCopyOnWriteLazy** suffers severely: `score` holds `m_writeMutex` to walk `rowIdx → docId → scalar` for all 10k target rows, H2D-syncs the result, then scores — driving score latency to ~10ms and throughput to only 103 calls/sec, 29x slower than Overwrite/COWEager. Upsert and delete are slower too because they contend with score on `m_writeMutex`.
+- **WorkerCopyOnWriteEager** also reaches near-full score throughput (2916/sec). Upsert is slightly slower than Overwrite (~16ms vs ~14ms) because it must carry scalars to the new rowIdx before flipping the dirty bit. UpdateScalar is also slightly slower (~3.2ms vs ~2.5ms) due to holding `m_scalarMutex` during the scatter to prevent scorers from reading mid-write.
+- **WorkerCopyOnWriteLazy** suffers severely: `score` holds `m_mapMutex` to walk `rowIdx → docId → scalar` for all 10k target rows, H2D-syncs the result, then scores — driving score latency to ~10ms and throughput to only 103 calls/sec, 29x slower than Overwrite/COWEager. Upsert and delete are slower too because they contend with score on `m_mapMutex`.
 
 ## Build
 

--- a/concurrent_read_write_paradigm/README.md
+++ b/concurrent_read_write_paradigm/README.md
@@ -114,14 +114,16 @@ The pseudo-code below shows the locking structure of each worker. Operations out
 ```
 score()
 {
-    { lock(globalMutex)
+    {
+        lock(globalMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    { lock(globalMutex)
+    {
+        lock(globalMutex)
         resolveMap()
         H2D()
         embScatterKernel()
@@ -130,7 +132,8 @@ upsert()
 
 updateScalar()
 {
-    { lock(globalMutex)
+    {
+        lock(globalMutex)
         resolveMap()
         H2D()
         scalarScatterKernel()
@@ -139,7 +142,8 @@ updateScalar()
 
 delete()
 {
-    { lock(globalMutex)
+    {
+        lock(globalMutex)
         resolveMap()
         H2D()
         setDirtyKernel()
@@ -152,40 +156,47 @@ delete()
 ```
 score()
 {
-    { lock(embDataMutex, scalarMutex, dirtyBitMutex)
+    {
+        lock(embDataMutex, scalarMutex, dirtyBitMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(embDataMutex)
+    {
+        lock(embDataMutex)
         embScatterKernel()
     }
 }
 
 updateScalar()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(scalarMutex)
+    {
+        lock(scalarMutex)
         scalarScatterKernel()
     }
 }
 
 delete()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirtyKernel()
     }
 }
@@ -196,48 +207,57 @@ delete()
 ```
 score()
 {
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirty(DIRTY)
     }
     embScatterKernel()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirty(CLEAN)
     }
 }
 
 updateScalar()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirty(DIRTY)
     }
     scalarScatterKernel()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirty(CLEAN)
     }
 }
 
 delete()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
     }
     H2D()
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         setDirtyKernel(DIRTY)
     }
 }
@@ -248,21 +268,24 @@ delete()
 ```
 score()
 {
-    { lock(dirtyBitMutex, scalarMutex)
+    {
+        lock(dirtyBitMutex, scalarMutex)
         scoreKernel()
     }
 }
 
 upsert()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
         H2D()
         embScatterKernel()
         carryScalarsH2D()
         scalarScatterKernel()
     }
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
@@ -271,11 +294,13 @@ upsert()
 
 updateScalar()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
         updateCPUScalars()
         H2D()
-        { lock(scalarMutex)
+        {
+            lock(scalarMutex)
             scalarScatterKernel()
         }
     }
@@ -283,11 +308,13 @@ updateScalar()
 
 delete()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
         eraseCPUScalars()
         H2D()
-        { lock(dirtyBitMutex)
+        {
+            lock(dirtyBitMutex)
             setDirtyKernel(DIRTY)
         }
     }
@@ -299,10 +326,12 @@ delete()
 ```
 score()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         snapshotScalarsFromCPU()
     }
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         H2D()
         scalarScatterKernel()
         scoreKernel()
@@ -311,12 +340,14 @@ score()
 
 upsert()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
         H2D()
         embScatterKernel()
     }
-    { lock(dirtyBitMutex)
+    {
+        lock(dirtyBitMutex)
         H2D(oldDirtyRowIdx)
         setDirty(old=DIRTY)
         setDirty(new=CLEAN)
@@ -325,18 +356,21 @@ upsert()
 
 updateScalar()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         updateCPUScalarsOnly()
     }
 }
 
 delete()
 {
-    { lock(mapMutex)
+    {
+        lock(mapMutex)
         resolveMap()
         eraseCPUScalars()
         H2D()
-        { lock(dirtyBitMutex)
+        {
+            lock(dirtyBitMutex)
             setDirtyKernel(DIRTY)
         }
     }

--- a/concurrent_read_write_paradigm/include/worker_cow.hpp
+++ b/concurrent_read_write_paradigm/include/worker_cow.hpp
@@ -38,8 +38,8 @@ protected:
                             const CudaDeviceArray<int>&  d_newRowIdx,
                             int                          numDocs);
 
-    std::mutex m_readMutex;  // locked only when dirty bits are modified or read
-    std::mutex m_writeMutex; // locked when rowIdx<>docId map or scalar map is modified
+    std::mutex m_mapMutex;      // protects CPU docId<>rowIdx map and scalar map
+    std::mutex m_dirtyBitMutex; // protects GPU dirty-bit array (m_d_dirty)
 
     std::unordered_map<long, std::vector<float>> m_docId2scalar; // CPU-side scalar store
 };
@@ -62,7 +62,8 @@ public:
                int                       targetScalarIdx) override;
 
 private:
-    void carryScalarsToNewRowIdx(const std::vector<long>& v_docId, const std::vector<int>& v_newRowIdx);
+    void       carryScalarsToNewRowIdx(const std::vector<long>& v_docId, const std::vector<int>& v_newRowIdx);
+    std::mutex m_scalarMutex; // protects GPU scalar array (m_d_scalars)
 };
 
 // Lazy variant: updateScalarData stores scalars on CPU only. upsertDocs does not

--- a/concurrent_read_write_paradigm/include/worker_overwrite.hpp
+++ b/concurrent_read_write_paradigm/include/worker_overwrite.hpp
@@ -13,10 +13,10 @@ public:
     void updateScalarData(const std::vector<long>& v_docId, const std::vector<std::vector<float>>& v2_scalar) override;
     void deleteDocs(const std::vector<long>& v_docId) override;
     void score(const std::vector<T_EMB>& v_reqEmb,
-               const std::vector<int>& v_targetRowIdx,
-               int targetScalarIdx) override;
+               const std::vector<int>&   v_targetRowIdx,
+               int                       targetScalarIdx) override;
 
 private:
-    std::mutex m_readMutex; // locked only when dirty bits are modified
-    std::mutex m_writeMutex; // locked when rowIdx<>docId map is modified
+    std::mutex m_mapMutex;      // protects CPU docId<>rowIdx map
+    std::mutex m_dirtyBitMutex; // protects GPU dirty-bit array (m_d_dirty)
 };

--- a/concurrent_read_write_paradigm/include/worker_split_lock.hpp
+++ b/concurrent_read_write_paradigm/include/worker_split_lock.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "worker.hpp"
+
+#include <mutex>
+
+// Two-mutex design without dirty bits:
+//   m_writeMutex: protects CPU maps (docId<>rowIdx) during resolution
+//   m_readMutex:  serializes GPU scatter kernels against the score kernel
+//
+// Unlike WorkerOverwrite, documents are never hidden (no dirty-bit fencing).
+// Score blocks only during the scatter kernel itself, not during H2D or map resolution.
+class WorkerSplitLock : public Worker
+{
+public:
+    WorkerSplitLock(int maxNumDocs, int embDim, int numScalars);
+
+    void upsertDocs(const std::vector<long>& v_docId, const std::vector<std::vector<T_EMB>>& v2_embData) override;
+    void updateScalarData(const std::vector<long>& v_docId, const std::vector<std::vector<float>>& v2_scalar) override;
+    void deleteDocs(const std::vector<long>& v_docId) override;
+    void score(const std::vector<T_EMB>& v_reqEmb,
+               const std::vector<int>&   v_targetRowIdx,
+               int                       targetScalarIdx) override;
+
+private:
+    std::mutex m_writeMutex; // protects CPU docId<>rowIdx maps
+    std::mutex m_readMutex;  // serializes GPU scatter kernels vs score kernel
+};

--- a/concurrent_read_write_paradigm/include/worker_split_lock.hpp
+++ b/concurrent_read_write_paradigm/include/worker_split_lock.hpp
@@ -4,12 +4,17 @@
 
 #include <mutex>
 
-// Two-mutex design without dirty bits:
-//   m_writeMutex: protects CPU maps (docId<>rowIdx) during resolution
-//   m_readMutex:  serializes GPU scatter kernels against the score kernel
+// Four-mutex design — one mutex per protected resource:
+//   m_mapMutex:      protects CPU docId<>rowIdx maps
+//   m_embDataMutex:  serializes GPU emb scatter (upsert) vs score kernel
+//   m_scalarMutex:   serializes GPU scalar scatter (updateScalar) vs score kernel
+//   m_dirtyBitMutex: serializes GPU dirty-bit writes (delete) vs score kernel
 //
-// Unlike WorkerOverwrite, documents are never hidden (no dirty-bit fencing).
-// Score blocks only during the scatter kernel itself, not during H2D or map resolution.
+// Writers hold m_mapMutex during map resolution, then the relevant GPU mutex
+// during the scatter kernel. Score holds all three GPU mutexes simultaneously
+// (acquired via std::scoped_lock to avoid deadlock). This allows upsert,
+// updateScalar, and delete to run concurrently with each other, while each
+// is still mutually exclusive with score on its specific GPU resource.
 class WorkerSplitLock : public Worker
 {
 public:
@@ -23,6 +28,8 @@ public:
                int                       targetScalarIdx) override;
 
 private:
-    std::mutex m_mapMutex; // protects CPU docId<>rowIdx maps
-    std::mutex m_gpuMutex; // serializes GPU scatter kernels vs score kernel
+    std::mutex m_mapMutex;      // protects CPU docId<>rowIdx maps
+    std::mutex m_embDataMutex;  // protects GPU embedding array (m_data)
+    std::mutex m_scalarMutex;   // protects GPU scalar array (m_d_scalars)
+    std::mutex m_dirtyBitMutex; // protects GPU dirty-bit array (m_d_dirty)
 };

--- a/concurrent_read_write_paradigm/include/worker_split_lock.hpp
+++ b/concurrent_read_write_paradigm/include/worker_split_lock.hpp
@@ -23,6 +23,6 @@ public:
                int                       targetScalarIdx) override;
 
 private:
-    std::mutex m_writeMutex; // protects CPU docId<>rowIdx maps
-    std::mutex m_readMutex;  // serializes GPU scatter kernels vs score kernel
+    std::mutex m_mapMutex; // protects CPU docId<>rowIdx maps
+    std::mutex m_gpuMutex; // serializes GPU scatter kernels vs score kernel
 };

--- a/concurrent_read_write_paradigm/src/worker_cow.cu
+++ b/concurrent_read_write_paradigm/src/worker_cow.cu
@@ -38,7 +38,7 @@ CopyOnWriteUpsertData WorkerCopyOnWrite::resolveAndScatterEmb(const std::vector<
                                                               const std::vector<std::vector<T_EMB>>& v2_embData,
                                                               CudaDeviceArray<int>&                  d_newRowIdx)
 {
-    // Caller must hold m_writeMutex.
+    // Caller must hold m_mapMutex.
     CopyOnWriteUpsertData upsertData;
     upsertData.v_embElement.reserve(v_docId.size() * m_embDim);
     upsertData.v_newRowIdx.reserve(v_docId.size());
@@ -123,7 +123,7 @@ void WorkerCopyOnWrite::commitDirtyBitFlip(const CopyOnWriteUpsertData& upsertDa
     const int kBlockSize = 256;
 
     // --- lock: protect dirty bits from concurrent score reads ---
-    std::lock_guard<std::mutex> lock(m_readMutex);
+    std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
 
     // Hide old rows first so scorers never see them after the new rows are revealed.
     // Only present for re-upserted (existing) docs; new docs have no old row to hide.
@@ -156,9 +156,9 @@ void WorkerCopyOnWrite::commitDirtyBitFlip(const CopyOnWriteUpsertData& upsertDa
 
 void WorkerCopyOnWrite::deleteDocs(const std::vector<long>& v_docId)
 {
-    // Hold m_writeMutex for the entire operation to serialize m_writeStream access
+    // Hold m_mapMutex for the entire operation to serialize m_writeStream access
     // with concurrent upsertDocs / updateScalarData.
-    std::lock_guard<std::mutex> writeLock(m_writeMutex);
+    std::lock_guard<std::mutex> mapLock(m_mapMutex);
 
     std::vector<int> v_deletedRowIdx = resolveDeletedRowIdxs(v_docId);
 
@@ -186,8 +186,8 @@ void WorkerCopyOnWrite::deleteDocs(const std::vector<long>& v_docId)
         {
             // --- lock: protect dirty bits from concurrent score reads ---
             // Sync inside the lock so m_d_dirty is fully written before any
-            // scorer can acquire m_readMutex and launch kn_score.
-            std::lock_guard<std::mutex> readLock(m_readMutex);
+            // scorer can acquire m_dirtyBitMutex and launch kn_score.
+            std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
             kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                           d_deletedRowIdx.data(),
                                                                           v_deletedRowIdx.size(),

--- a/concurrent_read_write_paradigm/src/worker_cow_eager.cu
+++ b/concurrent_read_write_paradigm/src/worker_cow_eager.cu
@@ -73,9 +73,9 @@ void WorkerCopyOnWriteEager::upsertDocs(const std::vector<long>&               v
 
     CopyOnWriteUpsertData upsertData;
     {
-        // Hold m_writeMutex across Phase 1 and 2 to serialize m_writeStream and m_docId2scalar
+        // Hold m_mapMutex across Phase 1 and 2 to serialize m_writeStream and m_docId2scalar
         // access with concurrent updateScalarData / deleteDocs.
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
 
         // Phase 1: allocate new rowIdxs, write emb data to GPU.
         upsertData = resolveAndScatterEmb(v_docId, v2_embData, d_newRowIdx);
@@ -95,9 +95,9 @@ void WorkerCopyOnWriteEager::upsertDocs(const std::vector<long>&               v
 void WorkerCopyOnWriteEager::updateScalarData(const std::vector<long>&               v_docId,
                                               const std::vector<std::vector<float>>& v2_scalar)
 {
-    // Hold m_writeMutex for the entire operation to serialize m_writeStream access
+    // Hold m_mapMutex for the entire operation to serialize m_writeStream access
     // with concurrent upsertDocs / deleteDocs.
-    std::lock_guard<std::mutex> writeLock(m_writeMutex);
+    std::lock_guard<std::mutex> mapLock(m_mapMutex);
 
     std::vector<ScalarElement> v_scalarElement = resolveScalarElements(v_docId, v2_scalar);
 
@@ -128,7 +128,7 @@ void WorkerCopyOnWriteEager::updateScalarData(const std::vector<long>&          
                                    m_writeStream.get()));
         CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
         int                         gridSize = (numElements + kBlockSize - 1) / kBlockSize;
-        std::lock_guard<std::mutex> readLock(m_readMutex);
+        std::lock_guard<std::mutex> scalarLock(m_scalarMutex);
         kn_scatter<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_scalars.data(),
                                                                      d_scalarElement.data(),
                                                                      m_numScalars,
@@ -142,6 +142,6 @@ void WorkerCopyOnWriteEager::score(const std::vector<T_EMB>& v_reqEmb,
                                    int                       targetScalarIdx)
 {
     // --- lock: protect dirty bits from concurrent write ops ---
-    std::lock_guard<std::mutex> lock(m_readMutex);
+    std::scoped_lock scoreLock(m_dirtyBitMutex, m_scalarMutex);
     scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
 }

--- a/concurrent_read_write_paradigm/src/worker_cow_lazy.cu
+++ b/concurrent_read_write_paradigm/src/worker_cow_lazy.cu
@@ -30,9 +30,9 @@ void WorkerCopyOnWriteLazy::upsertDocs(const std::vector<long>&               v_
 
     CopyOnWriteUpsertData upsertData;
     {
-        // Hold m_writeMutex across resolveAndScatterEmb to serialize m_writeStream access
+        // Hold m_mapMutex across resolveAndScatterEmb to serialize m_writeStream access
         // with concurrent updateScalarData / deleteDocs.
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
 
         // No scalar handling here — scalars are synced to GPU lazily in score().
         upsertData = resolveAndScatterEmb(v_docId, v2_embData, d_newRowIdx);
@@ -49,7 +49,7 @@ void WorkerCopyOnWriteLazy::updateScalarData(const std::vector<long>&           
                                              const std::vector<std::vector<float>>& v2_scalar)
 {
     // --- lock: protect scalar map ---
-    std::lock_guard<std::mutex> lock(m_writeMutex);
+    std::lock_guard<std::mutex> mapLock(m_mapMutex);
 
     for (int i = 0; i < (int)v_docId.size(); i++)
     {
@@ -61,12 +61,12 @@ void WorkerCopyOnWriteLazy::score(const std::vector<T_EMB>& v_reqEmb,
                                   const std::vector<int>&   v_targetRowIdx,
                                   int                       targetScalarIdx)
 {
-    // Snapshot scalars from the CPU maps under m_writeMutex before taking m_readMutex.
-    // Both m_rowIdx2DocId and m_docId2scalar are written under m_writeMutex; reading
-    // them without that lock would be a data race. Lock ordering: m_writeMutex first.
+    // Snapshot scalars from the CPU maps under m_mapMutex before taking m_dirtyBitMutex.
+    // Both m_rowIdx2DocId and m_docId2scalar are written under m_mapMutex; reading
+    // them without that lock would be a data race. Lock ordering: m_mapMutex first.
     std::vector<ScalarElement> v_scalarElement;
     {
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_scalarElement.reserve(v_targetRowIdx.size() * m_numScalars);
         for (int rowIdx : v_targetRowIdx)
         {
@@ -84,7 +84,7 @@ void WorkerCopyOnWriteLazy::score(const std::vector<T_EMB>& v_reqEmb,
     {
         const int kBlockSize = 256;
 
-        std::lock_guard<std::mutex>    readLock(m_readMutex);
+        std::lock_guard<std::mutex>    dirtyBitLock(m_dirtyBitMutex);
         CudaDeviceArray<ScalarElement> d_scalarElement(v_scalarElement.size(), "scalarElements");
         CHECK_CUDA(cudaMemcpyAsync(d_scalarElement.data(),
                                    v_scalarElement.data(),

--- a/concurrent_read_write_paradigm/src/worker_overwrite.cu
+++ b/concurrent_read_write_paradigm/src/worker_overwrite.cu
@@ -65,7 +65,7 @@ void WorkerOverwrite::upsertDocs(const std::vector<long>& v_docId, const std::ve
     std::vector<EmbElement> v_element;
     {
         // --- lock: protect docId<>rowIdx map ---
-        std::lock_guard<std::mutex> lock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_element = resolveAndBuildEmbElements(v_docId, v2_embData);
     }
 
@@ -96,7 +96,7 @@ void WorkerOverwrite::upsertDocs(const std::vector<long>& v_docId, const std::ve
     // --- set dirty=1 before scatter ---
     {
         // --- lock: protect dirty bits from concurrent score reads ---
-        std::lock_guard<std::mutex> lock(m_readMutex);
+        std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
         kn_setDirty<<<dirtyGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                            d_element.data(),
                                                                            m_embDim,
@@ -117,7 +117,7 @@ void WorkerOverwrite::upsertDocs(const std::vector<long>& v_docId, const std::ve
     // --- clear dirty=0 after scatter ---
     {
         // --- lock: protect dirty bits from concurrent score reads ---
-        std::lock_guard<std::mutex> lock(m_readMutex);
+        std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
         kn_setDirty<<<dirtyGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                            d_element.data(),
                                                                            m_embDim,
@@ -134,7 +134,7 @@ void WorkerOverwrite::updateScalarData(const std::vector<long>&               v_
     std::vector<ScalarElement> v_scalarElement;
     {
         // --- lock: protect docId<>rowIdx map ---
-        std::lock_guard<std::mutex> lock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_scalarElement = resolveScalarElements(v_docId, v2_scalar);
     }
 
@@ -181,7 +181,7 @@ void WorkerOverwrite::updateScalarData(const std::vector<long>&               v_
     // --- set dirty=1 before scatter ---
     {
         // --- lock: protect dirty bits from concurrent score reads ---
-        std::lock_guard<std::mutex> lock(m_readMutex);
+        std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
         kn_setDirty<<<dirtyGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                            d_dirtyRowIdx.data(),
                                                                            numDocs,
@@ -201,7 +201,7 @@ void WorkerOverwrite::updateScalarData(const std::vector<long>&               v_
     // --- clear dirty=0 after scatter ---
     {
         // --- lock: protect dirty bits from concurrent score reads ---
-        std::lock_guard<std::mutex> lock(m_readMutex);
+        std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
         kn_setDirty<<<dirtyGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                            d_dirtyRowIdx.data(),
                                                                            numDocs,
@@ -216,7 +216,7 @@ void WorkerOverwrite::deleteDocs(const std::vector<long>& v_docId)
     std::vector<int> v_deletedRowIdx;
     {
         // --- lock: protect docId<>rowIdx map ---
-        std::lock_guard<std::mutex> lock(m_writeMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_deletedRowIdx = resolveDeletedRowIdxs(v_docId);
     }
 
@@ -239,8 +239,8 @@ void WorkerOverwrite::deleteDocs(const std::vector<long>& v_docId)
         {
             // --- lock: protect dirty bits from concurrent score reads ---
             // Sync inside the lock so m_d_dirty is fully written before any
-            // scorer can acquire m_readMutex and launch kn_score.
-            std::lock_guard<std::mutex> lock(m_readMutex);
+            // scorer can acquire m_dirtyBitMutex and launch kn_score.
+            std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
             kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                           d_deletedRowIdx.data(),
                                                                           v_deletedRowIdx.size(),
@@ -255,6 +255,6 @@ void WorkerOverwrite::score(const std::vector<T_EMB>& v_reqEmb,
                             int                       targetScalarIdx)
 {
     // --- lock: protect dirty bits from concurrent write ops ---
-    std::lock_guard<std::mutex> lock(m_readMutex);
+    std::lock_guard<std::mutex> lock(m_dirtyBitMutex);
     scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
 }

--- a/concurrent_read_write_paradigm/src/worker_split_lock.cu
+++ b/concurrent_read_write_paradigm/src/worker_split_lock.cu
@@ -46,7 +46,7 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
     // --- resolve docId -> rowIdx and build emb elements ---
     std::vector<EmbElement> v_element;
     {
-        std::lock_guard<std::mutex> writeLock(m_mapMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_element = resolveAndBuildEmbElements(v_docId, v2_embData);
     }
 
@@ -69,7 +69,7 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
 
     // --- scatter: exclusive with score kernel ---
     {
-        std::lock_guard<std::mutex> readLock(m_gpuMutex);
+        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_data.data(),
                                                                             d_element.data(),
                                                                             m_embDim,
@@ -84,7 +84,7 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
     // --- resolve docId -> rowIdx and build scalar elements ---
     std::vector<ScalarElement> v_scalarElement;
     {
-        std::lock_guard<std::mutex> writeLock(m_mapMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_scalarElement = resolveScalarElements(v_docId, v2_scalar);
     }
 
@@ -107,7 +107,7 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
 
     // --- scatter: exclusive with score kernel ---
     {
-        std::lock_guard<std::mutex> readLock(m_gpuMutex);
+        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_scalars.data(),
                                                                             d_scalarElement.data(),
                                                                             m_numScalars,
@@ -121,7 +121,7 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
     // --- update maps, collect deleted rowIdxs ---
     std::vector<int> v_deletedRowIdx;
     {
-        std::lock_guard<std::mutex> writeLock(m_mapMutex);
+        std::lock_guard<std::mutex> mapLock(m_mapMutex);
         v_deletedRowIdx = resolveDeletedRowIdxs(v_docId);
     }
 
@@ -146,7 +146,7 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
     // Sync inside the lock so m_d_dirty is fully written before any scorer
     // can acquire m_gpuMutex and launch kn_score.
     {
-        std::lock_guard<std::mutex> readLock(m_gpuMutex);
+        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
         kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                       d_deletedRowIdx.data(),
                                                                       v_deletedRowIdx.size());
@@ -158,6 +158,6 @@ void WorkerSplitLock::score(const std::vector<T_EMB>& v_reqEmb,
                             const std::vector<int>&   v_targetRowIdx,
                             int                       targetScalarIdx)
 {
-    std::lock_guard<std::mutex> readLock(m_gpuMutex);
+    std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
     scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
 }

--- a/concurrent_read_write_paradigm/src/worker_split_lock.cu
+++ b/concurrent_read_write_paradigm/src/worker_split_lock.cu
@@ -1,0 +1,163 @@
+#include "utils/util.hpp"
+#include "worker_split_lock.hpp"
+
+#include <vector>
+
+// Scatters embedding values to non-contiguous rows. Each thread writes one T_EMB value.
+static __global__ void kn_scatter(T_EMB* d_dst, const EmbElement* d_elements, int embDim, int numElements)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= numElements)
+    {
+        return;
+    }
+    d_dst[d_elements[t].rowIdx * embDim + t % embDim] = d_elements[t].val;
+}
+
+// Scatters scalar values to non-contiguous (row, scalarIdx) locations.
+static __global__ void kn_scatter(float* d_dst, const ScalarElement* d_elements, int numScalars, int numElements)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= numElements)
+    {
+        return;
+    }
+    d_dst[d_elements[t].rowIdx * numScalars + d_elements[t].scalarIdx] = d_elements[t].val;
+}
+
+// Marks deleted rows as dirty so scorers skip them.
+static __global__ void kn_setDirty(DirtyBit* d_dirty, const int* d_rowIdx, int numElements)
+{
+    int t = blockIdx.x * blockDim.x + threadIdx.x;
+    if (t >= numElements)
+    {
+        return;
+    }
+    d_dirty[d_rowIdx[t]] = DirtyBit::DIRTY;
+}
+
+WorkerSplitLock::WorkerSplitLock(int maxNumDocs, int embDim, int numScalars)
+    : Worker(maxNumDocs, embDim, numScalars)
+{
+}
+
+void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::vector<std::vector<T_EMB>>& v2_embData)
+{
+    // --- resolve docId -> rowIdx and build emb elements ---
+    std::vector<EmbElement> v_element;
+    {
+        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        v_element = resolveAndBuildEmbElements(v_docId, v2_embData);
+    }
+
+    if (v_element.empty())
+    {
+        return;
+    }
+
+    const int kBlockSize      = 256;
+    const int scatterGridSize = (v_element.size() + kBlockSize - 1) / kBlockSize;
+
+    // --- H2D: can overlap with score (no GPU memory touched yet) ---
+    CudaDeviceArray<EmbElement> d_element(v_element.size(), "EmbElements");
+    CHECK_CUDA(cudaMemcpyAsync(d_element.data(),
+                               v_element.data(),
+                               v_element.size() * sizeof(EmbElement),
+                               cudaMemcpyHostToDevice,
+                               m_writeStream.get()));
+    CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+
+    // --- scatter: exclusive with score kernel ---
+    {
+        std::lock_guard<std::mutex> readLock(m_readMutex);
+        kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_data.data(),
+                                                                            d_element.data(),
+                                                                            m_embDim,
+                                                                            v_element.size());
+        CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+    }
+}
+
+void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_docId,
+                                       const std::vector<std::vector<float>>& v2_scalar)
+{
+    // --- resolve docId -> rowIdx and build scalar elements ---
+    std::vector<ScalarElement> v_scalarElement;
+    {
+        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        v_scalarElement = resolveScalarElements(v_docId, v2_scalar);
+    }
+
+    if (v_scalarElement.empty())
+    {
+        return;
+    }
+
+    const int kBlockSize      = 256;
+    const int scatterGridSize = (v_scalarElement.size() + kBlockSize - 1) / kBlockSize;
+
+    // --- H2D: can overlap with score ---
+    CudaDeviceArray<ScalarElement> d_scalarElement(v_scalarElement.size(), "scalarElements");
+    CHECK_CUDA(cudaMemcpyAsync(d_scalarElement.data(),
+                               v_scalarElement.data(),
+                               v_scalarElement.size() * sizeof(ScalarElement),
+                               cudaMemcpyHostToDevice,
+                               m_writeStream.get()));
+    CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+
+    // --- scatter: exclusive with score kernel ---
+    {
+        std::lock_guard<std::mutex> readLock(m_readMutex);
+        kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_scalars.data(),
+                                                                            d_scalarElement.data(),
+                                                                            m_numScalars,
+                                                                            v_scalarElement.size());
+        CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+    }
+}
+
+void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
+{
+    // --- update maps, collect deleted rowIdxs ---
+    std::vector<int> v_deletedRowIdx;
+    {
+        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        v_deletedRowIdx = resolveDeletedRowIdxs(v_docId);
+    }
+
+    if (v_deletedRowIdx.empty())
+    {
+        return;
+    }
+
+    const int kBlockSize = 256;
+    const int gridSize   = (v_deletedRowIdx.size() + kBlockSize - 1) / kBlockSize;
+
+    // --- H2D: can overlap with score ---
+    CudaDeviceArray<int> d_deletedRowIdx(v_deletedRowIdx.size(), "deletedRowIdx");
+    CHECK_CUDA(cudaMemcpyAsync(d_deletedRowIdx.data(),
+                               v_deletedRowIdx.data(),
+                               v_deletedRowIdx.size() * sizeof(int),
+                               cudaMemcpyHostToDevice,
+                               m_writeStream.get()));
+    CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+
+    // --- set dirty=1: exclusive with score kernel ---
+    // Sync inside the lock so m_d_dirty is fully written before any scorer
+    // can acquire m_readMutex and launch kn_score.
+    {
+        std::lock_guard<std::mutex> readLock(m_readMutex);
+        kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
+                                                                      d_deletedRowIdx.data(),
+                                                                      v_deletedRowIdx.size());
+        CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
+    }
+}
+
+void WorkerSplitLock::score(const std::vector<T_EMB>& v_reqEmb,
+                            const std::vector<int>&   v_targetRowIdx,
+                            int                       targetScalarIdx)
+{
+    std::lock_guard<std::mutex> readLock(m_readMutex);
+    scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
+}

--- a/concurrent_read_write_paradigm/src/worker_split_lock.cu
+++ b/concurrent_read_write_paradigm/src/worker_split_lock.cu
@@ -58,7 +58,7 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
     const int kBlockSize      = 256;
     const int scatterGridSize = (v_element.size() + kBlockSize - 1) / kBlockSize;
 
-    // --- H2D: can overlap with score (no GPU memory touched yet) ---
+    // --- H2D: can overlap with score and other writers ---
     CudaDeviceArray<EmbElement> d_element(v_element.size(), "EmbElements");
     CHECK_CUDA(cudaMemcpyAsync(d_element.data(),
                                v_element.data(),
@@ -67,9 +67,9 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
                                m_writeStream.get()));
     CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
 
-    // --- scatter: exclusive with score kernel ---
+    // --- scatter: exclusive with score on m_data ---
     {
-        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
+        std::lock_guard<std::mutex> embDataLock(m_embDataMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_data.data(),
                                                                             d_element.data(),
                                                                             m_embDim,
@@ -96,7 +96,7 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
     const int kBlockSize      = 256;
     const int scatterGridSize = (v_scalarElement.size() + kBlockSize - 1) / kBlockSize;
 
-    // --- H2D: can overlap with score ---
+    // --- H2D: can overlap with score and other writers ---
     CudaDeviceArray<ScalarElement> d_scalarElement(v_scalarElement.size(), "scalarElements");
     CHECK_CUDA(cudaMemcpyAsync(d_scalarElement.data(),
                                v_scalarElement.data(),
@@ -105,9 +105,9 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
                                m_writeStream.get()));
     CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
 
-    // --- scatter: exclusive with score kernel ---
+    // --- scatter: exclusive with score on m_d_scalars ---
     {
-        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
+        std::lock_guard<std::mutex> scalarLock(m_scalarMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_scalars.data(),
                                                                             d_scalarElement.data(),
                                                                             m_numScalars,
@@ -133,7 +133,7 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
     const int kBlockSize = 256;
     const int gridSize   = (v_deletedRowIdx.size() + kBlockSize - 1) / kBlockSize;
 
-    // --- H2D: can overlap with score ---
+    // --- H2D: can overlap with score and other writers ---
     CudaDeviceArray<int> d_deletedRowIdx(v_deletedRowIdx.size(), "deletedRowIdx");
     CHECK_CUDA(cudaMemcpyAsync(d_deletedRowIdx.data(),
                                v_deletedRowIdx.data(),
@@ -142,11 +142,11 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
                                m_writeStream.get()));
     CHECK_CUDA(cudaStreamSynchronize(m_writeStream.get()));
 
-    // --- set dirty=1: exclusive with score kernel ---
+    // --- set dirty=1: exclusive with score on m_d_dirty ---
     // Sync inside the lock so m_d_dirty is fully written before any scorer
-    // can acquire m_gpuMutex and launch kn_score.
+    // can acquire m_dirtyBitMutex and launch kn_score.
     {
-        std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
+        std::lock_guard<std::mutex> dirtyBitLock(m_dirtyBitMutex);
         kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                       d_deletedRowIdx.data(),
                                                                       v_deletedRowIdx.size());
@@ -158,6 +158,7 @@ void WorkerSplitLock::score(const std::vector<T_EMB>& v_reqEmb,
                             const std::vector<int>&   v_targetRowIdx,
                             int                       targetScalarIdx)
 {
-    std::lock_guard<std::mutex> gpuLock(m_gpuMutex);
+    // Acquire all three GPU mutexes atomically to avoid deadlock.
+    std::scoped_lock gpuLock(m_embDataMutex, m_scalarMutex, m_dirtyBitMutex);
     scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
 }

--- a/concurrent_read_write_paradigm/src/worker_split_lock.cu
+++ b/concurrent_read_write_paradigm/src/worker_split_lock.cu
@@ -46,7 +46,7 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
     // --- resolve docId -> rowIdx and build emb elements ---
     std::vector<EmbElement> v_element;
     {
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> writeLock(m_mapMutex);
         v_element = resolveAndBuildEmbElements(v_docId, v2_embData);
     }
 
@@ -69,7 +69,7 @@ void WorkerSplitLock::upsertDocs(const std::vector<long>& v_docId, const std::ve
 
     // --- scatter: exclusive with score kernel ---
     {
-        std::lock_guard<std::mutex> readLock(m_readMutex);
+        std::lock_guard<std::mutex> readLock(m_gpuMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_data.data(),
                                                                             d_element.data(),
                                                                             m_embDim,
@@ -84,7 +84,7 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
     // --- resolve docId -> rowIdx and build scalar elements ---
     std::vector<ScalarElement> v_scalarElement;
     {
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> writeLock(m_mapMutex);
         v_scalarElement = resolveScalarElements(v_docId, v2_scalar);
     }
 
@@ -107,7 +107,7 @@ void WorkerSplitLock::updateScalarData(const std::vector<long>&               v_
 
     // --- scatter: exclusive with score kernel ---
     {
-        std::lock_guard<std::mutex> readLock(m_readMutex);
+        std::lock_guard<std::mutex> readLock(m_gpuMutex);
         kn_scatter<<<scatterGridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_scalars.data(),
                                                                             d_scalarElement.data(),
                                                                             m_numScalars,
@@ -121,7 +121,7 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
     // --- update maps, collect deleted rowIdxs ---
     std::vector<int> v_deletedRowIdx;
     {
-        std::lock_guard<std::mutex> writeLock(m_writeMutex);
+        std::lock_guard<std::mutex> writeLock(m_mapMutex);
         v_deletedRowIdx = resolveDeletedRowIdxs(v_docId);
     }
 
@@ -144,9 +144,9 @@ void WorkerSplitLock::deleteDocs(const std::vector<long>& v_docId)
 
     // --- set dirty=1: exclusive with score kernel ---
     // Sync inside the lock so m_d_dirty is fully written before any scorer
-    // can acquire m_readMutex and launch kn_score.
+    // can acquire m_gpuMutex and launch kn_score.
     {
-        std::lock_guard<std::mutex> readLock(m_readMutex);
+        std::lock_guard<std::mutex> readLock(m_gpuMutex);
         kn_setDirty<<<gridSize, kBlockSize, 0, m_writeStream.get()>>>(m_d_dirty.data(),
                                                                       d_deletedRowIdx.data(),
                                                                       v_deletedRowIdx.size());
@@ -158,6 +158,6 @@ void WorkerSplitLock::score(const std::vector<T_EMB>& v_reqEmb,
                             const std::vector<int>&   v_targetRowIdx,
                             int                       targetScalarIdx)
 {
-    std::lock_guard<std::mutex> readLock(m_readMutex);
+    std::lock_guard<std::mutex> readLock(m_gpuMutex);
     scoreImpl(v_reqEmb, v_targetRowIdx, targetScalarIdx);
 }

--- a/concurrent_read_write_paradigm/test/test_concurrent_read_write_paradigm.cu
+++ b/concurrent_read_write_paradigm/test/test_concurrent_read_write_paradigm.cu
@@ -1,6 +1,7 @@
 #include "worker_cow.hpp"
 #include "worker_naive.hpp"
 #include "worker_overwrite.hpp"
+#include "worker_split_lock.hpp"
 
 #include <algorithm>
 #include <atomic>
@@ -331,6 +332,8 @@ int main()
 
     std::vector<WorkerDef> v_workerDef = {
         { "WorkerNaive", [&]() { return std::make_unique<WorkerNaive>(cfg.maxNumDocs, cfg.embDim, cfg.numScalars); } },
+        { "WorkerSplitLock",
+          [&]() { return std::make_unique<WorkerSplitLock>(cfg.maxNumDocs, cfg.embDim, cfg.numScalars); } },
         { "WorkerOverwrite",
           [&]() { return std::make_unique<WorkerOverwrite>(cfg.maxNumDocs, cfg.embDim, cfg.numScalars); } },
         { "WorkerCopyOnWriteEager",


### PR DESCRIPTION
## Summary

- Adds **WorkerSplitLock**: a new worker with four fine-grained mutexes — one per protected resource (`m_mapMutex`, `m_embDataMutex`, `m_scalarMutex`, `m_dirtyBitMutex`). Score holds all three GPU mutexes via `std::scoped_lock`; each writer holds only the mutex for its resource, allowing upsert, updateScalar, and delete to run concurrently with each other (while each remains exclusive with score on its specific GPU resource). H2D transfers happen outside all locks.
- Renames mutexes across all existing workers from the generic `m_readMutex`/`m_writeMutex` to resource-specific names (`m_mapMutex`, `m_dirtyBitMutex`, `m_scalarMutex`), making it clear what each lock protects.
- WorkerCopyOnWriteEager gains a separate `m_scalarMutex` for its scalar scatter; `score` holds `scoped_lock(m_dirtyBitMutex, m_scalarMutex)`.

## Test plan

- [ ] Build passes cleanly
- [ ] WorkerSplitLock appears in benchmark output alongside existing workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)