### PR TITLE
Add blog repo location to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,10 @@ When creating a new file, immediately `git add` it.
 
 Never use `git add -A` or `git add .`. Always add specific files by name.
 
+## Repos
+
+- `~/ycjuan.github.io` — my blog repo
+
 ## Shortcuts
 
 - **cmc** — "check my comments": fetch and display all unresolved PR review comments on the current branch, then ask the user which ones to act on. Use the GitHub GraphQL API (not REST) because only GraphQL exposes `isResolved` per thread:


### PR DESCRIPTION
## Summary

- Documents `~/ycjuan.github.io` as the blog repo in `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)