### PR TITLE
pytorch_inference_cpp: Add AOTInductor as a 5th inference backend

### DIFF
--- a/pytorch_inference_cpp/.gitignore
+++ b/pytorch_inference_cpp/.gitignore
@@ -1,3 +1,4 @@
 model.pt
 model.onnx
+model.pt2
 weights/

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -125,6 +125,24 @@ Model: query\_dim=64, doc\_dim=128, hidden=[256, 128], num\_heads=2.
 
 TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime because they compile GPU kernels ahead of time and auto-tune tiling for the exact input shape. Pure CUDA uses generic cuBLAS GEMMs without that auto-tuning. The key difference between TensorRT and AOTInductor: TensorRT requires a separate install, while AOTInductor ships as part of LibTorch.
 
+## TensorRT vs AOTInductor
+
+Both compile GPU kernels ahead of time and auto-tune tiling for the exact input shape, giving similar latency (~2 ms on a T4). The choice comes down to ecosystem fit:
+
+**TensorRT advantages:**
+- Slightly faster in practice — more aggressive kernel fusion and selection
+- More mature for production serving; widely used in industry
+- Better quantization support (INT8, FP16) out of the box
+- Not tied to PyTorch — works with any ONNX-compatible framework
+
+**AOTInductor advantages:**
+- **No extra install** — ships as part of LibTorch; TensorRT is a separate heavy dependency
+- **Simpler workflow** — `torch.export` → `.pt2` → C++, all within the PyTorch ecosystem; TensorRT adds an ONNX intermediate step
+- **Actively developed** — TorchScript (the old PyTorch C++ serving path) is deprecated; AOTInductor is its official replacement
+- **Dynamic shapes are first-class** — TensorRT requires manually configuring optimization profiles (min/opt/max); AOTInductor handles dynamic dims more naturally via `torch.export.Dim`
+
+**Bottom line:** TensorRT is the better choice if you need maximum GPU performance and are already in the NVIDIA ecosystem. AOTInductor is the better choice if you want a simpler, PyTorch-native path with nearly the same speed — and it is where PyTorch is actively investing.
+
 ## Run everything end-to-end
 
 To export, compile, and run all five approaches in one shot:

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -1,6 +1,6 @@
 # PyTorch Inference in C++
 
-Demonstrates four approaches to serve a PyTorch model in pure C++ with no Python runtime.
+Demonstrates five approaches to serve a PyTorch model in pure C++ with no Python runtime.
 
 ## Model
 
@@ -11,26 +11,26 @@ A 2-tower MLP scorer (query + doc):
 
 ## Dependency comparison
 
-| | TorchScript | ONNX Runtime | TensorRT | Pure CUDA |
-|---|---|---|---|---|
-| Convert via | `torch.jit.trace` | `torch.onnx.export` | `torch.onnx.export` | weight dump |
-| Convert deps | PyTorch | PyTorch + `onnx` | PyTorch + `onnx` | PyTorch |
-| Model file | `model.pt` | `model.onnx` | `model.onnx` | `weights/*.bin` |
-| C++ library | LibTorch | ONNX Runtime | TensorRT + CUDA | cuBLAS only |
-| NVIDIA GPU required | No | No | Yes | Yes |
-| PyTorch at serve time | No | No | No | No |
+| | TorchScript | ONNX Runtime | TensorRT | Pure CUDA | AOTInductor |
+|---|---|---|---|---|---|
+| Convert via | `torch.jit.trace` | `torch.onnx.export` | `torch.onnx.export` | weight dump | `torch.export` |
+| Convert deps | PyTorch | PyTorch + `onnx` | PyTorch + `onnx` | PyTorch | PyTorch |
+| Model file | `model.pt` | `model.onnx` | `model.onnx` | `weights/*.bin` | `model.pt2` |
+| C++ library | LibTorch | ONNX Runtime | TensorRT + CUDA | cuBLAS only | LibTorch |
+| NVIDIA GPU required | No | No | Yes | Yes | Yes |
+| PyTorch at serve time | No | No | No | No | No |
 
 ## Step 1: Export the model
 
 ```bash
 pip install torch onnx
 python3 export.py
-# Produces: model.pt, model.onnx, weights/
+# Produces: model.pt, model.onnx, model.pt2, weights/
 ```
 
 ## Step 2: Install dependencies
 
-### LibTorch (TorchScript and compare)
+### LibTorch (TorchScript, AOTInductor, and compare)
 
 ```bash
 cd ~/external && wget https://download.pytorch.org/libtorch/cu128/libtorch-shared-with-deps-2.8.0%2Bcu128.zip && unzip libtorch-*.zip
@@ -90,7 +90,15 @@ cd tensorrt && ./compile.sh && ./run.sh
 cd cuda && ./compile.sh && ./run.sh
 ```
 
-## Step 4: Run all four and assert they agree
+### Approach 5: AOTInductor (requires GPU)
+
+Uses `torch.export` + `torch._inductor.aoti_compile_and_package` to compile the model into a `.pt2` package with Inductor's kernel auto-tuning. Loaded in C++ via `AOTIModelPackageLoader`, which is part of LibTorch — no extra dependency beyond LibTorch.
+
+```bash
+cd aotinductor && ./compile.sh && ./run.sh
+```
+
+## Step 4: Run all five and assert they agree
 
 ```bash
 cd compare && ./compile.sh && ./run.sh
@@ -99,25 +107,27 @@ cd compare && ./compile.sh && ./run.sh
 Expected output:
 
 ```
-[PASS] ONNX Runtime vs TorchScript
-[PASS] TensorRT     vs TorchScript
-[PASS] Pure CUDA    vs TorchScript
+[PASS] ONNX Runtime  vs TorchScript
+[PASS] TensorRT      vs TorchScript
+[PASS] Pure CUDA     vs TorchScript
+[PASS] AOTInductor   vs TorchScript
 
 Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
-  TorchScript  :    9.12 ms
-  ONNX Runtime :   11.78 ms
-  TensorRT     :    1.96 ms
-  Pure CUDA    :    3.13 ms
+  TorchScript  :   10.71 ms
+  ONNX Runtime :   12.27 ms
+  TensorRT     :    2.01 ms
+  Pure CUDA    :    3.24 ms
+  AOTInductor  :    2.24 ms
 ```
 
 Benchmark config: Amazon Linux 2023, CUDA 12.9, TensorRT 11, T4 GPU.
 Model: query\_dim=64, doc\_dim=128, hidden=[256, 128], num\_heads=2.
 
-TensorRT is ~7x faster than TorchScript/ONNX Runtime because its engine compilation step tunes kernel tiling for the exact shape. Pure CUDA sits in between, using generic cuBLAS without TRT's auto-tuning.
+TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime because they compile GPU kernels ahead of time and auto-tune tiling for the exact input shape. Pure CUDA uses generic cuBLAS GEMMs without that auto-tuning. The key difference between TensorRT and AOTInductor: TensorRT requires a separate install, while AOTInductor ships as part of LibTorch.
 
 ## Run everything end-to-end
 
-To export, compile, and run all four approaches in one shot:
+To export, compile, and run all five approaches in one shot:
 
 ```bash
 ./run.sh

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -120,10 +120,20 @@ Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
   AOTInductor  :    2.24 ms
 ```
 
-Benchmark config: Amazon Linux 2023, CUDA 12.9, TensorRT 11, T4 GPU.
-Model: query\_dim=64, doc\_dim=128, hidden=[256, 128], num\_heads=2.
+## Benchmark
 
-TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime because they compile GPU kernels ahead of time and auto-tune tiling for the exact input shape. Pure CUDA uses generic cuBLAS GEMMs without that auto-tuning. The key difference between TensorRT and AOTInductor: TensorRT requires a separate install, while AOTInductor ships as part of LibTorch.
+Config: Amazon Linux 2023, CUDA 12.9, TensorRT 11, T4 GPU.
+Model: query\_dim=64, doc\_dim=128, hidden=[256, 128], num\_heads=2, num\_docs=10000.
+
+| Backend | Latency |
+|---|---|
+| TorchScript | 10.71 ms |
+| ONNX Runtime | 12.27 ms |
+| Pure CUDA | 3.24 ms |
+| **AOTInductor** | **2.24 ms** |
+| **TensorRT** | **2.01 ms** |
+
+TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime because they compile GPU kernels ahead of time and auto-tune tiling for the exact input shape. Pure CUDA uses generic cuBLAS GEMMs without that auto-tuning.
 
 ## TensorRT vs AOTInductor
 

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -127,21 +127,8 @@ TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime becau
 
 ## TensorRT vs AOTInductor
 
-Both compile GPU kernels ahead of time and auto-tune tiling for the exact input shape, giving similar latency (~2 ms on a T4). The choice comes down to ecosystem fit:
-
-**TensorRT advantages:**
-- Slightly faster in practice — more aggressive kernel fusion and selection
-- More mature for production serving; widely used in industry
-- Better quantization support (INT8, FP16) out of the box
-- Not tied to PyTorch — works with any ONNX-compatible framework
-
-**AOTInductor advantages:**
-- **No extra install** — ships as part of LibTorch; TensorRT is a separate heavy dependency
-- **Simpler workflow** — `torch.export` → `.pt2` → C++, all within the PyTorch ecosystem; TensorRT adds an ONNX intermediate step
-- **Actively developed** — TorchScript (the old PyTorch C++ serving path) is deprecated; AOTInductor is its official replacement
-- **Dynamic shapes are first-class** — TensorRT requires manually configuring optimization profiles (min/opt/max); AOTInductor handles dynamic dims more naturally via `torch.export.Dim`
-
-**Bottom line:** TensorRT is the better choice if you need maximum GPU performance and are already in the NVIDIA ecosystem. AOTInductor is the better choice if you want a simpler, PyTorch-native path with nearly the same speed — and it is where PyTorch is actively investing.
+- **TensorRT**: slightly faster; supports all ONNX-compatible models, not just PyTorch
+- **AOTInductor**: PyTorch-native, no dependency beyond LibTorch
 
 ## Run everything end-to-end
 

--- a/pytorch_inference_cpp/aotinductor/CMakeLists.txt
+++ b/pytorch_inference_cpp/aotinductor/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.18)
+project(aotinductor_inference LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
+
+# Download LibTorch from https://pytorch.org/get-started/locally/
+# and set: cmake -DCMAKE_PREFIX_PATH=/path/to/libtorch ..
+find_package(Torch REQUIRED)
+
+add_executable(inference main.cu)
+target_link_libraries(inference ${TORCH_LIBRARIES})
+
+set_property(TARGET inference PROPERTY CXX_STANDARD 17)
+foreach(flag ${TORCH_CXX_FLAGS})
+    target_compile_options(inference PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${flag}>)
+endforeach()

--- a/pytorch_inference_cpp/aotinductor/compile.sh
+++ b/pytorch_inference_cpp/aotinductor/compile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+LIBTORCH_ROOT=~/external/libtorch
+
+mkdir -p build && cd build
+cmake .. -DCMAKE_PREFIX_PATH=$LIBTORCH_ROOT
+make -j$(nproc)

--- a/pytorch_inference_cpp/aotinductor/main.cu
+++ b/pytorch_inference_cpp/aotinductor/main.cu
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <torch/csrc/inductor/aoti_package/model_package_loader.h>
+#include <torch/torch.h>
+
+int main()
+{
+    torch::inductor::AOTIModelPackageLoader loader("../model.pt2");
+
+    const int query_dim = 64;
+    const int doc_dim   = 128;
+    const int num_docs  = 5;
+
+    auto opts  = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
+    auto query = torch::randn({ query_dim }, opts);
+    auto docs  = torch::randn({ num_docs, doc_dim }, opts);
+
+    auto outputs = loader.run({ query, docs });
+    auto scores  = outputs[0].cpu();
+
+    std::cout << "Scores shape: [" << scores.size(0) << ", " << scores.size(1) << "]\n";
+    std::cout << "Scores:\n" << scores << "\n";
+
+    return 0;
+}

--- a/pytorch_inference_cpp/aotinductor/run.sh
+++ b/pytorch_inference_cpp/aotinductor/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+LD_LIBRARY_PATH=~/external/libtorch/lib:$LD_LIBRARY_PATH ./build/inference

--- a/pytorch_inference_cpp/compare/CMakeLists.txt
+++ b/pytorch_inference_cpp/compare/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(compare
     backend_onnxruntime.cu
     backend_tensorrt.cu
     backend_cuda.cu
+    backend_aotinductor.cu
 )
 
 target_include_directories(compare PRIVATE

--- a/pytorch_inference_cpp/compare/backend_aotinductor.cu
+++ b/pytorch_inference_cpp/compare/backend_aotinductor.cu
@@ -1,0 +1,32 @@
+#include "backends.hpp"
+#include <torch/csrc/inductor/aoti_package/model_package_loader.h>
+#include <torch/torch.h>
+
+struct AOTInductorBackend : InferBackend
+{
+    torch::inductor::AOTIModelPackageLoader loader;
+
+    explicit AOTInductorBackend(const Paths& paths)
+        : loader(paths.aoti_model)
+    {
+    }
+
+    std::vector<float> infer(const Input& in) override
+    {
+        auto opts = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
+        auto query
+            = torch::from_blob(const_cast<float*>(in.query.data()), { in.query_dim }, torch::kFloat32).clone().to(opts);
+        auto docs = torch::from_blob(const_cast<float*>(in.docs.data()), { in.num_docs, in.doc_dim }, torch::kFloat32)
+                        .clone()
+                        .to(opts);
+
+        auto outputs = loader.run({ query, docs });
+        auto scores  = outputs[0].cpu().contiguous();
+        return std::vector<float>(scores.data_ptr<float>(), scores.data_ptr<float>() + scores.numel());
+    }
+};
+
+std::unique_ptr<InferBackend> make_aotinductor(const Paths& paths)
+{
+    return std::make_unique<AOTInductorBackend>(paths);
+}

--- a/pytorch_inference_cpp/compare/backends.hpp
+++ b/pytorch_inference_cpp/compare/backends.hpp
@@ -18,6 +18,7 @@ struct Paths
     std::string torchscript_model; // model.pt
     std::string onnx_model;        // model.onnx
     std::string weights_dir;       // weights/
+    std::string aoti_model;        // model.pt2
 };
 
 // Abstract backend: construct once (loads/compiles the model), call infer() many times.
@@ -32,3 +33,4 @@ std::unique_ptr<InferBackend> make_torchscript(const Paths& paths);
 std::unique_ptr<InferBackend> make_onnxruntime(const Paths& paths);
 std::unique_ptr<InferBackend> make_tensorrt(const Paths& paths, const Input& profile_input);
 std::unique_ptr<InferBackend> make_cuda(const Paths& paths, const Input& shape_hint);
+std::unique_ptr<InferBackend> make_aotinductor(const Paths& paths);

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -49,23 +49,26 @@ int main()
 
     Input in { query, docs, num_docs, query_dim, doc_dim, num_heads };
 
-    Paths paths { "../model.pt", "../model.onnx", "../weights/" };
+    Paths paths { "../model.pt", "../model.onnx", "../weights/", "../model.pt2" };
 
     std::cout << "Initializing backends...\n";
-    auto ts  = make_torchscript(paths);
-    auto ort = make_onnxruntime(paths);
-    auto trt = make_tensorrt(paths, in);
-    auto cu  = make_cuda(paths, in);
+    auto ts   = make_torchscript(paths);
+    auto ort  = make_onnxruntime(paths);
+    auto trt  = make_tensorrt(paths, in);
+    auto cu   = make_cuda(paths, in);
+    auto aoti = make_aotinductor(paths);
 
     std::cout << "Checking correctness (num_docs=10000)...\n";
-    auto ref     = ts->infer(in);
-    auto got_ort = ort->infer(in);
-    auto got_trt = trt->infer(in);
-    auto got_cu  = cu->infer(in);
+    auto ref      = ts->infer(in);
+    auto got_ort  = ort->infer(in);
+    auto got_trt  = trt->infer(in);
+    auto got_cu   = cu->infer(in);
+    auto got_aoti = aoti->infer(in);
 
-    assertEqual(ref, got_ort, "ONNX Runtime vs TorchScript");
-    assertEqual(ref, got_trt, "TensorRT     vs TorchScript");
-    assertEqual(ref, got_cu, "Pure CUDA    vs TorchScript");
+    assertEqual(ref, got_ort, "ONNX Runtime  vs TorchScript");
+    assertEqual(ref, got_trt, "TensorRT      vs TorchScript");
+    assertEqual(ref, got_cu, "Pure CUDA     vs TorchScript");
+    assertEqual(ref, got_aoti, "AOTInductor   vs TorchScript");
 
     const int numTrials       = 10;
     const int numWarmupTrials = 3;
@@ -75,6 +78,7 @@ int main()
     printf("  ONNX Runtime : %7.2f ms\n", benchMs(*ort, in, numWarmupTrials, numTrials));
     printf("  TensorRT     : %7.2f ms\n", benchMs(*trt, in, numWarmupTrials, numTrials));
     printf("  Pure CUDA    : %7.2f ms\n", benchMs(*cu, in, numWarmupTrials, numTrials));
+    printf("  AOTInductor  : %7.2f ms\n", benchMs(*aoti, in, numWarmupTrials, numTrials));
 
     return 0;
 }

--- a/pytorch_inference_cpp/export.py
+++ b/pytorch_inference_cpp/export.py
@@ -113,6 +113,19 @@ for i, layer in enumerate(model.hidden):
 save_tensor(model.output.weight, "w_out.bin")        # [num_heads, H_last]
 save_tensor(model.output.bias,   "b_out.bin")        # [num_heads]
 
+# --- Approach 5: AOTInductor ---
+# Weights are baked into the compiled .pt2 package.
+# The model is moved to CUDA for GPU-optimized kernel generation.
+model_cuda = model.cuda()
+num_docs_dim = torch.export.Dim("num_docs", min=1, max=100000)
+ep = torch.export.export(
+    model_cuda,
+    (dummy_query.cuda(), dummy_docs.cuda()),
+    dynamic_shapes=(None, {0: num_docs_dim}),
+)
+torch._inductor.aoti_compile_and_package(ep, package_path="model.pt2")
+print("Saved model.pt2 (AOTInductor)")
+
 # Also save config so the C++ side knows the dims
 import json
 config = {

--- a/pytorch_inference_cpp/run.sh
+++ b/pytorch_inference_cpp/run.sh
@@ -39,6 +39,13 @@ cd "$SCRIPT_DIR"
 
 echo ""
 echo "============================================================"
+echo "Step 5b: AOTInductor"
+echo "============================================================"
+cd aotinductor && ./compile.sh && ./run.sh
+cd "$SCRIPT_DIR"
+
+echo ""
+echo "============================================================"
 echo "Step 6: Compare all backends + benchmark"
 echo "============================================================"
 cd compare && ./compile.sh && ./run.sh

--- a/pytorch_inference_cpp/run.sh
+++ b/pytorch_inference_cpp/run.sh
@@ -39,14 +39,14 @@ cd "$SCRIPT_DIR"
 
 echo ""
 echo "============================================================"
-echo "Step 5b: AOTInductor"
+echo "Step 6: AOTInductor"
 echo "============================================================"
 cd aotinductor && ./compile.sh && ./run.sh
 cd "$SCRIPT_DIR"
 
 echo ""
 echo "============================================================"
-echo "Step 6: Compare all backends + benchmark"
+echo "Step 7: Compare all backends + benchmark"
 echo "============================================================"
 cd compare && ./compile.sh && ./run.sh
 cd "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary

Adds AOTInductor (`torch.export` + `torch._inductor.aoti_compile_and_package`) as a fifth C++ inference backend alongside TorchScript, ONNX Runtime, TensorRT, and Pure CUDA.

- **Export**: `torch.export.export()` → `torch._inductor.aoti_compile_and_package()` → `model.pt2`
- **Serve**: `torch::inductor::AOTIModelPackageLoader` C++ API (part of LibTorch, no extra dependency)
- Weights are baked into the compiled `.pt2` package; model is compiled for CUDA at export time
- Dynamic `num_docs` dimension supported via `torch.export.Dim`

## Benchmark (T4 GPU, num_docs=10000)

| Backend | Latency |
|---|---|
| TorchScript | 10.71 ms |
| ONNX Runtime | 12.27 ms |
| **TensorRT** | **2.01 ms** |
| **AOTInductor** | **2.24 ms** |
| Pure CUDA | 3.24 ms |

AOTInductor is very close to TensorRT — Inductor performs kernel auto-tuning similar to TRT's engine compilation, without requiring a separate TensorRT installation.

## Test plan

- [x] `python3 export.py` — produces `model.pt2` in addition to existing artifacts
- [x] `cd aotinductor && ./compile.sh && ./run.sh` — standalone inference works
- [x] `cd compare && ./compile.sh && ./run.sh` — `[PASS] AOTInductor vs TorchScript` and latency printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)