### PR TITLE
pytorch_inference_cpp: Separately benchmark H2D transfer, kernel, and D2H transfer

### DIFF
--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -109,8 +109,8 @@ Expected output:
 ```
 [PASS] ONNX Runtime  vs TorchScript
 [PASS] TensorRT      vs TorchScript
-[PASS] Pure CUDA     vs TorchScript
 [PASS] AOTInductor   vs TorchScript
+[PASS] Pure CUDA     vs TorchScript
 
 Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
 
@@ -136,9 +136,9 @@ The benchmark separately times three segments: **[A]** copying query and doc emb
 |---|---|---|
 | TorchScript | 10.75 ms | — |
 | ONNX Runtime | 12.63 ms | — |
+| **TensorRT** | **1.77 ms** | **0.59 ms** |
 | AOTInductor | 1.80 ms | 0.62 ms |
 | Pure CUDA | 2.62 ms | 1.44 ms |
-| **TensorRT** | **1.77 ms** | **0.59 ms** |
 
 H2D transfer (1.14 ms) and D2H transfer (0.04 ms) are shared across all GPU backends. The e2e column is kernel + transfer.
 

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -84,18 +84,18 @@ directly — `nvonnxparser` parses it at startup to compile a GPU-optimized engi
 cd tensorrt && ./compile.sh && ./run.sh
 ```
 
-### Approach 4: Pure CUDA + cuBLAS
-
-```bash
-cd cuda && ./compile.sh && ./run.sh
-```
-
-### Approach 5: AOTInductor (requires GPU)
+### Approach 4: AOTInductor (requires GPU)
 
 Uses `torch.export` + `torch._inductor.aoti_compile_and_package` to compile the model into a `.pt2` package with Inductor's kernel auto-tuning. Loaded in C++ via `AOTIModelPackageLoader`, which is part of LibTorch — no extra dependency beyond LibTorch.
 
 ```bash
 cd aotinductor && ./compile.sh && ./run.sh
+```
+
+### Approach 5: Pure CUDA + cuBLAS
+
+```bash
+cd cuda && ./compile.sh && ./run.sh
 ```
 
 ## Step 4: Run all five and assert they agree
@@ -121,8 +121,8 @@ Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
   TorchScript     e2e:  10.75 ms
   ONNX Runtime    e2e:  12.63 ms
   TensorRT        e2e:   1.77 ms  kernel:   0.59 ms
-  Pure CUDA       e2e:   2.62 ms  kernel:   1.44 ms
   AOTInductor     e2e:   1.80 ms  kernel:   0.62 ms
+  Pure CUDA       e2e:   2.62 ms  kernel:   1.44 ms
 ```
 
 ## Benchmark
@@ -136,8 +136,8 @@ The benchmark separately times three segments: **[A]** copying query and doc emb
 |---|---|---|
 | TorchScript | 10.75 ms | — |
 | ONNX Runtime | 12.63 ms | — |
-| Pure CUDA | 2.62 ms | 1.44 ms |
 | AOTInductor | 1.80 ms | 0.62 ms |
+| Pure CUDA | 2.62 ms | 1.44 ms |
 | **TensorRT** | **1.77 ms** | **0.59 ms** |
 
 H2D transfer (1.14 ms) and D2H transfer (0.04 ms) are shared across all GPU backends. The e2e column is kernel + transfer.

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -11,12 +11,12 @@ A 2-tower MLP scorer (query + doc):
 
 ## Dependency comparison
 
-| | TorchScript | ONNX Runtime | TensorRT | Pure CUDA | AOTInductor |
+| | TorchScript | ONNX Runtime | TensorRT | AOTInductor | Pure CUDA |
 |---|---|---|---|---|---|
-| Convert via | `torch.jit.trace` | `torch.onnx.export` | `torch.onnx.export` | weight dump | `torch.export` |
+| Convert via | `torch.jit.trace` | `torch.onnx.export` | `torch.onnx.export` | `torch.export` | weight dump |
 | Convert deps | PyTorch | PyTorch + `onnx` | PyTorch + `onnx` | PyTorch | PyTorch |
-| Model file | `model.pt` | `model.onnx` | `model.onnx` | `weights/*.bin` | `model.pt2` |
-| C++ library | LibTorch | ONNX Runtime | TensorRT + CUDA | cuBLAS only | LibTorch |
+| Model file | `model.pt` | `model.onnx` | `model.onnx` | `model.pt2` | `weights/*.bin` |
+| C++ library | LibTorch | ONNX Runtime | TensorRT + CUDA | LibTorch | cuBLAS only |
 | NVIDIA GPU required | No | No | Yes | Yes | Yes |
 | PyTorch at serve time | No | No | No | No | No |
 

--- a/pytorch_inference_cpp/README.md
+++ b/pytorch_inference_cpp/README.md
@@ -113,11 +113,16 @@ Expected output:
 [PASS] AOTInductor   vs TorchScript
 
 Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
-  TorchScript  :   10.71 ms
-  ONNX Runtime :   12.27 ms
-  TensorRT     :    2.01 ms
-  Pure CUDA    :    3.24 ms
-  AOTInductor  :    2.24 ms
+
+  [A] H2D transfer              :   1.14 ms
+  [C] D2H transfer              :   0.04 ms
+  [A+C] total transfer          :   1.18 ms
+
+  TorchScript     e2e:  10.75 ms
+  ONNX Runtime    e2e:  12.63 ms
+  TensorRT        e2e:   1.77 ms  kernel:   0.59 ms
+  Pure CUDA       e2e:   2.62 ms  kernel:   1.44 ms
+  AOTInductor     e2e:   1.80 ms  kernel:   0.62 ms
 ```
 
 ## Benchmark
@@ -125,13 +130,19 @@ Benchmarking (num_docs=10000, 3 warmup + 10 trials)...
 Config: Amazon Linux 2023, CUDA 12.9, TensorRT 11, T4 GPU.
 Model: query\_dim=64, doc\_dim=128, hidden=[256, 128], num\_heads=2, num\_docs=10000.
 
-| Backend | Latency |
-|---|---|
-| TorchScript | 10.71 ms |
-| ONNX Runtime | 12.27 ms |
-| Pure CUDA | 3.24 ms |
-| **AOTInductor** | **2.24 ms** |
-| **TensorRT** | **2.01 ms** |
+The benchmark separately times three segments: **[A]** copying query and doc embeddings from CPU to GPU (H2D), **[B]** the inference kernel itself, and **[C]** copying scores back from GPU to CPU (D2H). This makes the comparison fair — H2D/D2H costs are the same across all GPU backends, so kernel time isolates each approach's actual compute efficiency.
+
+| Backend | e2e | kernel only |
+|---|---|---|
+| TorchScript | 10.75 ms | — |
+| ONNX Runtime | 12.63 ms | — |
+| Pure CUDA | 2.62 ms | 1.44 ms |
+| AOTInductor | 1.80 ms | 0.62 ms |
+| **TensorRT** | **1.77 ms** | **0.59 ms** |
+
+H2D transfer (1.14 ms) and D2H transfer (0.04 ms) are shared across all GPU backends. The e2e column is kernel + transfer.
+
+**TorchScript and ONNX Runtime cannot report kernel-only time.** They are CPU-side runtimes that manage their own internal GPU memory, so there is no API to inject pre-allocated device pointers and skip the H2D step — inference is always an end-to-end black box.
 
 TensorRT and AOTInductor are both ~5x faster than TorchScript/ONNX Runtime because they compile GPU kernels ahead of time and auto-tune tiling for the exact input shape. Pure CUDA uses generic cuBLAS GEMMs without that auto-tuning.
 

--- a/pytorch_inference_cpp/clean.sh
+++ b/pytorch_inference_cpp/clean.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+for dir in torchscript onnxruntime tensorrt cuda aotinductor compare; do
+    rm -rf "$SCRIPT_DIR/$dir/build"
+done
+
+echo "Done."

--- a/pytorch_inference_cpp/compare/backend_aotinductor.cu
+++ b/pytorch_inference_cpp/compare/backend_aotinductor.cu
@@ -1,4 +1,5 @@
 #include "backends.hpp"
+#include <cuda_runtime.h>
 #include <torch/csrc/inductor/aoti_package/model_package_loader.h>
 #include <torch/torch.h>
 
@@ -11,18 +12,49 @@ struct AOTInductorBackend : InferBackend
     {
     }
 
+    bool supports_device_infer() const override { return true; }
+
+    void infer_device(const float* d_query,
+                      const float* d_docs,
+                      float*       d_scores,
+                      int          query_dim,
+                      int          doc_dim,
+                      int          num_docs,
+                      int          num_heads) override
+    {
+        auto opts  = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
+        auto query = torch::from_blob(const_cast<float*>(d_query), { query_dim }, opts);
+        auto docs  = torch::from_blob(const_cast<float*>(d_docs), { num_docs, doc_dim }, opts);
+
+        auto outputs    = loader.run({ query, docs });
+        auto scores_gpu = outputs[0].contiguous(); // [num_docs x num_heads] on GPU
+        cudaMemcpy(d_scores,
+                   scores_gpu.data_ptr<float>(),
+                   num_docs * num_heads * sizeof(float),
+                   cudaMemcpyDeviceToDevice);
+    }
+
     std::vector<float> infer(const Input& in) override
     {
-        auto opts = torch::TensorOptions().device(torch::kCUDA).dtype(torch::kFloat32);
-        auto query
-            = torch::from_blob(const_cast<float*>(in.query.data()), { in.query_dim }, torch::kFloat32).clone().to(opts);
-        auto docs = torch::from_blob(const_cast<float*>(in.docs.data()), { in.num_docs, in.doc_dim }, torch::kFloat32)
-                        .clone()
-                        .to(opts);
+        float* d_query  = nullptr;
+        float* d_docs   = nullptr;
+        float* d_scores = nullptr;
+        cudaMalloc(&d_query, in.query.size() * sizeof(float));
+        cudaMalloc(&d_docs, in.docs.size() * sizeof(float));
+        cudaMalloc(&d_scores, in.num_docs * in.num_heads * sizeof(float));
 
-        auto outputs = loader.run({ query, docs });
-        auto scores  = outputs[0].cpu().contiguous();
-        return std::vector<float>(scores.data_ptr<float>(), scores.data_ptr<float>() + scores.numel());
+        cudaMemcpy(d_query, in.query.data(), in.query.size() * sizeof(float), cudaMemcpyHostToDevice);
+        cudaMemcpy(d_docs, in.docs.data(), in.docs.size() * sizeof(float), cudaMemcpyHostToDevice);
+
+        infer_device(d_query, d_docs, d_scores, in.query_dim, in.doc_dim, in.num_docs, in.num_heads);
+
+        std::vector<float> scores(in.num_docs * in.num_heads);
+        cudaMemcpy(scores.data(), d_scores, scores.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+        cudaFree(d_query);
+        cudaFree(d_docs);
+        cudaFree(d_scores);
+        return scores;
     }
 };
 

--- a/pytorch_inference_cpp/compare/backend_cuda.cu
+++ b/pytorch_inference_cpp/compare/backend_cuda.cu
@@ -153,8 +153,7 @@ struct CudaBackend : InferBackend
         d_b1       = upload("b1.bin");
         d_w1_doc   = upload("w1_doc.bin");
 
-        // Infer hidden_sizes from weight files
-        hidden_sizes.push_back(static_cast<int>(d_b1.n)); // H1 = size of b1
+        hidden_sizes.push_back(static_cast<int>(d_b1.n));
         for (int i = 0;; ++i)
         {
             std::ifstream f(wdir + "w_hidden_" + std::to_string(i) + ".bin", std::ios::binary);
@@ -163,7 +162,6 @@ struct CudaBackend : InferBackend
             f.seekg(0, std::ios::end);
             int prev = hidden_sizes.back();
             hidden_sizes.push_back(static_cast<int>(f.tellg() / sizeof(float)) / prev);
-
             d_w_hidden.push_back(upload("w_hidden_" + std::to_string(i) + ".bin"));
             d_b_hidden.push_back(upload("b_hidden_" + std::to_string(i) + ".bin"));
         }
@@ -174,33 +172,31 @@ struct CudaBackend : InferBackend
 
     ~CudaBackend() { cublasDestroy(handle); }
 
-    std::vector<float> infer(const Input& in) override
+    bool supports_device_infer() const override { return true; }
+
+    // d_scores output is col-major [num_heads x num_docs] (native cuBLAS layout).
+    void infer_device(const float* d_query,
+                      const float* d_docs,
+                      float*       d_scores,
+                      int          query_dim_,
+                      int          doc_dim_,
+                      int          num_docs,
+                      int          num_heads_) override
     {
-        const int num_docs = in.num_docs;
-        const int H1       = hidden_sizes[0];
-        const int maxH     = *std::max_element(hidden_sizes.begin(), hidden_sizes.end());
-
-        GpuBuf d_query(in.query_dim);
-        d_query.upload(in.query);
-
-        // docs row-major [num_docs x doc_dim] == col-major [doc_dim x num_docs]: same memory layout
-        GpuBuf d_docs(in.docs.size());
-        d_docs.upload(in.docs);
+        const int H1   = hidden_sizes[0];
+        const int maxH = *std::max_element(hidden_sizes.begin(), hidden_sizes.end());
 
         GpuBuf d_query_proj(H1);
         GpuBuf d_act_a(maxH * num_docs);
         GpuBuf d_act_b(maxH * num_docs);
-        GpuBuf d_scores(num_heads * num_docs);
 
-        // Layer 1: query_proj = W1_query @ query + b1
-        gemv(handle, d_w1_query.ptr, H1, in.query_dim, d_query.ptr, d_query_proj.ptr);
+        gemv(handle, d_w1_query.ptr, H1, query_dim_, d_query, d_query_proj.ptr);
         {
             const float alpha = 1.0f;
             CHECK_CUBLAS(cublasSaxpy(handle, H1, &alpha, d_b1.ptr, 1, d_query_proj.ptr, 1));
         }
 
-        // Layer 1: act = ReLU(W1_doc @ docs + query_proj)
-        gemm(handle, d_w1_doc.ptr, H1, in.doc_dim, d_docs.ptr, num_docs, d_act_a.ptr);
+        gemm(handle, d_w1_doc.ptr, H1, doc_dim_, d_docs, num_docs, d_act_a.ptr);
         {
             dim3 block(16, 16);
             dim3 grid((H1 + 15) / 16, (num_docs + 15) / 16);
@@ -208,7 +204,6 @@ struct CudaBackend : InferBackend
             reluInPlace<<<(H1 * num_docs + 255) / 256, 256>>>(d_act_a.ptr, H1 * num_docs);
         }
 
-        // Hidden layers
         GpuBuf* src = &d_act_a;
         GpuBuf* dst = &d_act_b;
         for (size_t i = 0; i + 1 < hidden_sizes.size(); ++i)
@@ -225,23 +220,33 @@ struct CudaBackend : InferBackend
             std::swap(src, dst);
         }
 
-        // Output layer + sigmoid
         const int H_last = hidden_sizes.back();
-        gemm(handle, d_w_out.ptr, num_heads, H_last, src->ptr, num_docs, d_scores.ptr);
+        gemm(handle, d_w_out.ptr, num_heads_, H_last, src->ptr, num_docs, d_scores);
         {
             dim3 block(16, 16);
-            dim3 grid((num_heads + 15) / 16, (num_docs + 15) / 16);
-            addBiasColMajor<<<grid, block>>>(d_scores.ptr, d_b_out.ptr, num_heads, num_docs);
-            sigmoidInPlace<<<(num_heads * num_docs + 255) / 256, 256>>>(d_scores.ptr, num_heads * num_docs);
+            dim3 grid((num_heads_ + 15) / 16, (num_docs + 15) / 16);
+            addBiasColMajor<<<grid, block>>>(d_scores, d_b_out.ptr, num_heads_, num_docs);
+            sigmoidInPlace<<<(num_heads_ * num_docs + 255) / 256, 256>>>(d_scores, num_heads_ * num_docs);
         }
         CHECK_CUDA(cudaDeviceSynchronize());
+    }
 
-        // d_scores is [num_heads x num_docs] col-major → convert to [num_docs x num_heads] row-major
+    std::vector<float> infer(const Input& in) override
+    {
+        GpuBuf d_query(in.query_dim);
+        d_query.upload(in.query);
+        GpuBuf d_docs(in.docs.size());
+        d_docs.upload(in.docs);
+        GpuBuf d_scores(in.num_heads * in.num_docs);
+
+        infer_device(d_query.ptr, d_docs.ptr, d_scores.ptr, in.query_dim, in.doc_dim, in.num_docs, in.num_heads);
+
+        // d_scores is col-major [num_heads x num_docs] → reorder to row-major [num_docs x num_heads]
         auto               raw = d_scores.download();
-        std::vector<float> scores(num_heads * num_docs);
-        for (int d = 0; d < num_docs; ++d)
-            for (int h = 0; h < num_heads; ++h)
-                scores[d * num_heads + h] = raw[h + d * num_heads];
+        std::vector<float> scores(in.num_heads * in.num_docs);
+        for (int d = 0; d < in.num_docs; ++d)
+            for (int h = 0; h < in.num_heads; ++h)
+                scores[d * in.num_heads + h] = raw[h + d * in.num_heads];
         return scores;
     }
 };

--- a/pytorch_inference_cpp/compare/backend_onnxruntime.cu
+++ b/pytorch_inference_cpp/compare/backend_onnxruntime.cu
@@ -42,4 +42,7 @@ struct OnnxRuntimeBackend : InferBackend
     }
 };
 
-std::unique_ptr<InferBackend> make_onnxruntime(const Paths& paths) { return std::make_unique<OnnxRuntimeBackend>(paths); }
+std::unique_ptr<InferBackend> make_onnxruntime(const Paths& paths)
+{
+    return std::make_unique<OnnxRuntimeBackend>(paths);
+}

--- a/pytorch_inference_cpp/compare/backend_tensorrt.cu
+++ b/pytorch_inference_cpp/compare/backend_tensorrt.cu
@@ -37,7 +37,7 @@ struct TensorRTBackend : InferBackend
         parser->parseFromFile(paths.onnx_model.c_str(), static_cast<int>(nvinfer1::ILogger::Severity::kWARNING));
 
         std::unique_ptr<nvinfer1::IBuilderConfig> config(builder->createBuilderConfig());
-        config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 256 << 20); // 256 MB
+        config->setMemoryPoolLimit(nvinfer1::MemoryPoolType::kWORKSPACE, 256 << 20);
 
         const int                       max_docs = profile_input.num_docs;
         nvinfer1::IOptimizationProfile* profile  = builder->createOptimizationProfile();
@@ -53,11 +53,27 @@ struct TensorRTBackend : InferBackend
         context.reset(engine->createExecutionContext());
     }
 
+    bool supports_device_infer() const override { return true; }
+
+    void infer_device(const float* d_query,
+                      const float* d_docs,
+                      float*       d_scores,
+                      int          query_dim_,
+                      int          doc_dim_,
+                      int          num_docs,
+                      int          num_heads_) override
+    {
+        context->setInputShape("query", nvinfer1::Dims { 1, { query_dim_ } });
+        context->setInputShape("docs", nvinfer1::Dims2(num_docs, doc_dim_));
+        context->setTensorAddress("query", const_cast<float*>(d_query));
+        context->setTensorAddress("docs", const_cast<float*>(d_docs));
+        context->setTensorAddress("scores", d_scores);
+        context->enqueueV3(0);
+        cudaDeviceSynchronize();
+    }
+
     std::vector<float> infer(const Input& in) override
     {
-        context->setInputShape("query", nvinfer1::Dims { 1, { in.query_dim } });
-        context->setInputShape("docs", nvinfer1::Dims2(in.num_docs, in.doc_dim));
-
         void* d_query  = nullptr;
         void* d_docs   = nullptr;
         void* d_scores = nullptr;
@@ -68,11 +84,13 @@ struct TensorRTBackend : InferBackend
         cudaMemcpy(d_query, in.query.data(), in.query.size() * sizeof(float), cudaMemcpyHostToDevice);
         cudaMemcpy(d_docs, in.docs.data(), in.docs.size() * sizeof(float), cudaMemcpyHostToDevice);
 
-        context->setTensorAddress("query", d_query);
-        context->setTensorAddress("docs", d_docs);
-        context->setTensorAddress("scores", d_scores);
-        context->enqueueV3(0);
-        cudaDeviceSynchronize();
+        infer_device(static_cast<float*>(d_query),
+                     static_cast<float*>(d_docs),
+                     static_cast<float*>(d_scores),
+                     in.query_dim,
+                     in.doc_dim,
+                     in.num_docs,
+                     in.num_heads);
 
         std::vector<float> scores(in.num_docs * in.num_heads);
         cudaMemcpy(scores.data(), d_scores, scores.size() * sizeof(float), cudaMemcpyDeviceToHost);

--- a/pytorch_inference_cpp/compare/backend_torchscript.cu
+++ b/pytorch_inference_cpp/compare/backend_torchscript.cu
@@ -23,4 +23,7 @@ struct TorchScriptBackend : InferBackend
     }
 };
 
-std::unique_ptr<InferBackend> make_torchscript(const Paths& paths) { return std::make_unique<TorchScriptBackend>(paths); }
+std::unique_ptr<InferBackend> make_torchscript(const Paths& paths)
+{
+    return std::make_unique<TorchScriptBackend>(paths);
+}

--- a/pytorch_inference_cpp/compare/backends.hpp
+++ b/pytorch_inference_cpp/compare/backends.hpp
@@ -25,8 +25,31 @@ struct Paths
 // Separating init from infer lets benchmarks measure pure forward-pass latency.
 struct InferBackend
 {
-    virtual ~InferBackend()                           = default;
+    virtual ~InferBackend() = default;
+
+    // End-to-end inference (H2D + kernel + D2H). Used for correctness checks.
     virtual std::vector<float> infer(const Input& in) = 0;
+
+    // GPU backends implement this: kernel-only, inputs/outputs already on device.
+    // d_query: [query_dim], d_docs: [num_docs x doc_dim] (row-major),
+    // d_scores: [num_docs x num_heads] output (row-major).
+    virtual bool supports_device_infer() const { return false; }
+    virtual void infer_device(const float* d_query,
+                              const float* d_docs,
+                              float*       d_scores,
+                              int          query_dim,
+                              int          doc_dim,
+                              int          num_docs,
+                              int          num_heads)
+    {
+        (void)d_query;
+        (void)d_docs;
+        (void)d_scores;
+        (void)query_dim;
+        (void)doc_dim;
+        (void)num_docs;
+        (void)num_heads;
+    }
 };
 
 std::unique_ptr<InferBackend> make_torchscript(const Paths& paths);

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -71,8 +71,8 @@ int main()
 
     assertEqual(ref, got_ort, "ONNX Runtime  vs TorchScript");
     assertEqual(ref, got_trt, "TensorRT      vs TorchScript");
-    assertEqual(ref, got_cu, "Pure CUDA     vs TorchScript");
     assertEqual(ref, got_aoti, "AOTInductor   vs TorchScript");
+    assertEqual(ref, got_cu, "Pure CUDA     vs TorchScript");
 
     const int numTrials       = 10;
     const int numWarmupTrials = 3;

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -82,7 +82,7 @@ int main()
     std::vector<float> h_scores(num_docs * num_heads);
 
     // [A] H2D transfer
-    double msA = benchMs(
+    double msH2D = benchMs(
         [&]()
         {
             cudaMemcpy(d_query, in.query.data(), query_dim * sizeof(float), cudaMemcpyHostToDevice);
@@ -92,7 +92,7 @@ int main()
         numTrials);
 
     // [C] D2H transfer
-    double msC = benchMs(
+    double msD2H = benchMs(
         [&]() { cudaMemcpy(h_scores.data(), d_scores, num_docs * num_heads * sizeof(float), cudaMemcpyDeviceToHost); },
         numWarmupTrials,
         numTrials);
@@ -126,15 +126,15 @@ int main()
     std::cout << "\nBenchmarking (num_docs=" << num_docs << ", " << numWarmupTrials << " warmup + " << numTrials
               << " trials)...\n\n";
 
-    printf("  [A] H2D transfer              : %6.2f ms\n", msA);
-    printf("  [C] D2H transfer              : %6.2f ms\n", msC);
-    printf("  [A+C] total transfer          : %6.2f ms\n\n", msA + msC);
+    printf("  [A] H2D transfer              : %6.2f ms\n", msH2D);
+    printf("  [C] D2H transfer              : %6.2f ms\n", msD2H);
+    printf("  [A+C] total transfer          : %6.2f ms\n\n", msH2D + msD2H);
 
     printf("  %-14s  e2e: %6.2f ms\n", "TorchScript", msTs);
     printf("  %-14s  e2e: %6.2f ms\n", "ONNX Runtime", msOrt);
-    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", msTrt + msA + msC, msTrt);
-    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", msCu + msA + msC, msCu);
-    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", msAoti + msA + msC, msAoti);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", msTrt + msH2D + msD2H, msTrt);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", msCu + msH2D + msD2H, msCu);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", msAoti + msH2D + msD2H, msAoti);
 
     return 0;
 }

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -1,6 +1,7 @@
 #include "backends.hpp"
 #include <chrono>
 #include <cmath>
+#include <cuda_runtime.h>
 #include <iostream>
 #include <stdexcept>
 
@@ -15,6 +16,44 @@ static double benchMs(InferBackend& backend, const Input& in, int warmup, int it
     for (int i = 0; i < iters; ++i)
         backend.infer(in);
     auto t1 = Clock::now();
+
+    return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
+}
+
+// Measures the cost of copying query+docs H2D and scores D2H, with no compute.
+// This overhead is shared by all GPU backends and is subtracted to get kernel-only time.
+static double benchTransferMs(const Input& in, int warmup, int iters)
+{
+    const size_t query_bytes  = in.query.size() * sizeof(float);
+    const size_t docs_bytes   = in.docs.size() * sizeof(float);
+    const size_t scores_bytes = in.num_docs * in.num_heads * sizeof(float);
+
+    void* d_query;
+    void* d_docs;
+    void* d_scores;
+    cudaMalloc(&d_query, query_bytes);
+    cudaMalloc(&d_docs, docs_bytes);
+    cudaMalloc(&d_scores, scores_bytes);
+
+    std::vector<float> h_scores(in.num_docs * in.num_heads);
+    auto               doTransfer = [&]()
+    {
+        cudaMemcpy(d_query, in.query.data(), query_bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_docs, in.docs.data(), docs_bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(h_scores.data(), d_scores, scores_bytes, cudaMemcpyDeviceToHost);
+    };
+
+    for (int i = 0; i < warmup; ++i)
+        doTransfer();
+
+    auto t0 = Clock::now();
+    for (int i = 0; i < iters; ++i)
+        doTransfer();
+    auto t1 = Clock::now();
+
+    cudaFree(d_query);
+    cudaFree(d_docs);
+    cudaFree(d_scores);
 
     return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
 }
@@ -73,12 +112,22 @@ int main()
     const int numTrials       = 10;
     const int numWarmupTrials = 3;
 
+    const double transferMs = benchTransferMs(in, numWarmupTrials, numTrials);
+
     std::cout << "\nBenchmarking (num_docs=10000, " << numWarmupTrials << " warmup + " << numTrials << " trials)...\n";
-    printf("  TorchScript  : %7.2f ms\n", benchMs(*ts, in, numWarmupTrials, numTrials));
-    printf("  ONNX Runtime : %7.2f ms\n", benchMs(*ort, in, numWarmupTrials, numTrials));
-    printf("  TensorRT     : %7.2f ms\n", benchMs(*trt, in, numWarmupTrials, numTrials));
-    printf("  Pure CUDA    : %7.2f ms\n", benchMs(*cu, in, numWarmupTrials, numTrials));
-    printf("  AOTInductor  : %7.2f ms\n", benchMs(*aoti, in, numWarmupTrials, numTrials));
+    std::cout << "  H2D + D2H transfer : " << transferMs << " ms (subtracted from GPU backends below)\n\n";
+
+    const double tsMs   = benchMs(*ts, in, numWarmupTrials, numTrials);
+    const double ortMs  = benchMs(*ort, in, numWarmupTrials, numTrials);
+    const double trtMs  = benchMs(*trt, in, numWarmupTrials, numTrials);
+    const double cuMs   = benchMs(*cu, in, numWarmupTrials, numTrials);
+    const double aotiMs = benchMs(*aoti, in, numWarmupTrials, numTrials);
+
+    printf("  %-14s  total: %6.2f ms\n", "TorchScript", tsMs);
+    printf("  %-14s  total: %6.2f ms\n", "ONNX Runtime", ortMs);
+    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", trtMs, trtMs - transferMs);
+    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", cuMs, cuMs - transferMs);
+    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", aotiMs, aotiMs - transferMs);
 
     return 0;
 }

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -1,8 +1,10 @@
 #include "backends.hpp"
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <cuda_runtime.h>
 #include <iostream>
+#include <random>
 #include <stdexcept>
 
 using Clock = std::chrono::high_resolution_clock;
@@ -41,10 +43,13 @@ int main()
     const int num_docs  = 10000;
     const int num_heads = 2;
 
-    std::vector<float> query(query_dim, 0.5f);
+    std::mt19937                          rng(42);
+    std::uniform_real_distribution<float> dist(-1.0f, 1.0f);
+
+    std::vector<float> query(query_dim);
+    std::generate(query.begin(), query.end(), [&] { return dist(rng); });
     std::vector<float> docs(num_docs * doc_dim);
-    for (int i = 0; i < num_docs * doc_dim; ++i)
-        docs[i] = static_cast<float>(i % 7) / 7.0f;
+    std::generate(docs.begin(), docs.end(), [&] { return dist(rng); });
 
     Input in { query, docs, num_docs, query_dim, doc_dim, num_heads };
 

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -7,55 +7,15 @@
 
 using Clock = std::chrono::high_resolution_clock;
 
-static double benchMs(InferBackend& backend, const Input& in, int warmup, int iters)
+template <typename Fn>
+static double benchMs(Fn fn, int warmup, int iters)
 {
     for (int i = 0; i < warmup; ++i)
-        backend.infer(in);
-
+        fn();
     auto t0 = Clock::now();
     for (int i = 0; i < iters; ++i)
-        backend.infer(in);
-    auto t1 = Clock::now();
-
-    return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
-}
-
-// Measures the cost of copying query+docs H2D and scores D2H, with no compute.
-// This overhead is shared by all GPU backends and is subtracted to get kernel-only time.
-static double benchTransferMs(const Input& in, int warmup, int iters)
-{
-    const size_t query_bytes  = in.query.size() * sizeof(float);
-    const size_t docs_bytes   = in.docs.size() * sizeof(float);
-    const size_t scores_bytes = in.num_docs * in.num_heads * sizeof(float);
-
-    void* d_query;
-    void* d_docs;
-    void* d_scores;
-    cudaMalloc(&d_query, query_bytes);
-    cudaMalloc(&d_docs, docs_bytes);
-    cudaMalloc(&d_scores, scores_bytes);
-
-    std::vector<float> h_scores(in.num_docs * in.num_heads);
-    auto               doTransfer = [&]()
-    {
-        cudaMemcpy(d_query, in.query.data(), query_bytes, cudaMemcpyHostToDevice);
-        cudaMemcpy(d_docs, in.docs.data(), docs_bytes, cudaMemcpyHostToDevice);
-        cudaMemcpy(h_scores.data(), d_scores, scores_bytes, cudaMemcpyDeviceToHost);
-    };
-
-    for (int i = 0; i < warmup; ++i)
-        doTransfer();
-
-    auto t0 = Clock::now();
-    for (int i = 0; i < iters; ++i)
-        doTransfer();
-    auto t1 = Clock::now();
-
-    cudaFree(d_query);
-    cudaFree(d_docs);
-    cudaFree(d_scores);
-
-    return std::chrono::duration<double, std::milli>(t1 - t0).count() / iters;
+        fn();
+    return std::chrono::duration<double, std::milli>(Clock::now() - t0).count() / iters;
 }
 
 static void assertEqual(const std::vector<float>& ref,
@@ -97,7 +57,7 @@ int main()
     auto cu   = make_cuda(paths, in);
     auto aoti = make_aotinductor(paths);
 
-    std::cout << "Checking correctness (num_docs=10000)...\n";
+    std::cout << "Checking correctness (num_docs=" << num_docs << ")...\n";
     auto ref      = ts->infer(in);
     auto got_ort  = ort->infer(in);
     auto got_trt  = trt->infer(in);
@@ -112,22 +72,69 @@ int main()
     const int numTrials       = 10;
     const int numWarmupTrials = 3;
 
-    const double transferMs = benchTransferMs(in, numWarmupTrials, numTrials);
+    // Pre-allocate shared GPU buffers for A/B/C benchmarks
+    float* d_query  = nullptr;
+    float* d_docs   = nullptr;
+    float* d_scores = nullptr;
+    cudaMalloc(&d_query, query_dim * sizeof(float));
+    cudaMalloc(&d_docs, num_docs * doc_dim * sizeof(float));
+    cudaMalloc(&d_scores, num_docs * num_heads * sizeof(float));
+    std::vector<float> h_scores(num_docs * num_heads);
 
-    std::cout << "\nBenchmarking (num_docs=10000, " << numWarmupTrials << " warmup + " << numTrials << " trials)...\n";
-    std::cout << "  H2D + D2H transfer : " << transferMs << " ms (subtracted from GPU backends below)\n\n";
+    // [A] H2D transfer
+    double msA = benchMs(
+        [&]()
+        {
+            cudaMemcpy(d_query, in.query.data(), query_dim * sizeof(float), cudaMemcpyHostToDevice);
+            cudaMemcpy(d_docs, in.docs.data(), num_docs * doc_dim * sizeof(float), cudaMemcpyHostToDevice);
+        },
+        numWarmupTrials,
+        numTrials);
 
-    const double tsMs   = benchMs(*ts, in, numWarmupTrials, numTrials);
-    const double ortMs  = benchMs(*ort, in, numWarmupTrials, numTrials);
-    const double trtMs  = benchMs(*trt, in, numWarmupTrials, numTrials);
-    const double cuMs   = benchMs(*cu, in, numWarmupTrials, numTrials);
-    const double aotiMs = benchMs(*aoti, in, numWarmupTrials, numTrials);
+    // [C] D2H transfer
+    double msC = benchMs(
+        [&]() { cudaMemcpy(h_scores.data(), d_scores, num_docs * num_heads * sizeof(float), cudaMemcpyDeviceToHost); },
+        numWarmupTrials,
+        numTrials);
 
-    printf("  %-14s  total: %6.2f ms\n", "TorchScript", tsMs);
-    printf("  %-14s  total: %6.2f ms\n", "ONNX Runtime", ortMs);
-    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", trtMs, trtMs - transferMs);
-    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", cuMs, cuMs - transferMs);
-    printf("  %-14s  total: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", aotiMs, aotiMs - transferMs);
+    // Pre-fill d_query / d_docs once for kernel benchmarks
+    cudaMemcpy(d_query, in.query.data(), query_dim * sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(d_docs, in.docs.data(), num_docs * doc_dim * sizeof(float), cudaMemcpyHostToDevice);
+
+    // [B] Kernel-only benchmarks for GPU backends
+    double msTrt
+        = benchMs([&]() { trt->infer_device(d_query, d_docs, d_scores, query_dim, doc_dim, num_docs, num_heads); },
+                  numWarmupTrials,
+                  numTrials);
+    double msCu
+        = benchMs([&]() { cu->infer_device(d_query, d_docs, d_scores, query_dim, doc_dim, num_docs, num_heads); },
+                  numWarmupTrials,
+                  numTrials);
+    double msAoti
+        = benchMs([&]() { aoti->infer_device(d_query, d_docs, d_scores, query_dim, doc_dim, num_docs, num_heads); },
+                  numWarmupTrials,
+                  numTrials);
+
+    // E2E benchmarks for CPU backends (no H2D/D2H separation possible)
+    double msTs  = benchMs([&]() { ts->infer(in); }, numWarmupTrials, numTrials);
+    double msOrt = benchMs([&]() { ort->infer(in); }, numWarmupTrials, numTrials);
+
+    cudaFree(d_query);
+    cudaFree(d_docs);
+    cudaFree(d_scores);
+
+    std::cout << "\nBenchmarking (num_docs=" << num_docs << ", " << numWarmupTrials << " warmup + " << numTrials
+              << " trials)...\n\n";
+
+    printf("  [A] H2D transfer              : %6.2f ms\n", msA);
+    printf("  [C] D2H transfer              : %6.2f ms\n", msC);
+    printf("  [A+C] total transfer          : %6.2f ms\n\n", msA + msC);
+
+    printf("  %-14s  e2e: %6.2f ms\n", "TorchScript", msTs);
+    printf("  %-14s  e2e: %6.2f ms\n", "ONNX Runtime", msOrt);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", msTrt + msA + msC, msTrt);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", msCu + msA + msC, msCu);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", msAoti + msA + msC, msAoti);
 
     return 0;
 }

--- a/pytorch_inference_cpp/compare/main.cu
+++ b/pytorch_inference_cpp/compare/main.cu
@@ -138,8 +138,8 @@ int main()
     printf("  %-14s  e2e: %6.2f ms\n", "TorchScript", msTs);
     printf("  %-14s  e2e: %6.2f ms\n", "ONNX Runtime", msOrt);
     printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "TensorRT", msTrt + msH2D + msD2H, msTrt);
-    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", msCu + msH2D + msD2H, msCu);
     printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "AOTInductor", msAoti + msH2D + msD2H, msAoti);
+    printf("  %-14s  e2e: %6.2f ms  kernel: %6.2f ms\n", "Pure CUDA", msCu + msH2D + msD2H, msCu);
 
     return 0;
 }


### PR DESCRIPTION
## Summary

The previous benchmark lumped H2D transfer, kernel execution, and D2H transfer into a single timed loop, making it impossible to compare kernel performance across backends independently.

Changes:
- Add `infer_device()` to GPU backends (TensorRT, AOTInductor, Pure CUDA) — takes pre-allocated device pointers and runs the kernel only
- Pre-allocate shared GPU buffers in `main.cu`; time [A] H2D, [B] each kernel, [C] D2H independently
- Use `std::mt19937` + `std::uniform_real_distribution<float>(-1, 1)` for random query/doc embeddings
- Rename `msA`/`msC` → `msH2D`/`msD2H` for clarity
- Reorder backends: AOTInductor is method 4, Pure CUDA is method 5
- Add `PreToolUse` hook to run `clang-format` on staged C++ files before every `git commit`

TorchScript and ONNX Runtime are CPU-side runtimes with no API to inject pre-allocated device pointers, so they remain e2e-only.

Sample output:
```
  [A] H2D transfer              :   1.14 ms
  [C] D2H transfer              :   0.04 ms
  [A+C] total transfer          :   1.18 ms

  TorchScript     e2e:  10.75 ms
  ONNX Runtime    e2e:  12.63 ms
  TensorRT        e2e:   1.77 ms  kernel:   0.59 ms
  AOTInductor     e2e:   1.80 ms  kernel:   0.62 ms
  Pure CUDA       e2e:   2.62 ms  kernel:   1.44 ms
```

## Test plan

- [x] `cd compare && ./compile.sh && ./run.sh` — all `[PASS]` and A/B/C columns print correctly for all five backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)