### PR TITLE
embedding_quantization: Add TurboQuant method

### DIFF
--- a/embedding_quantization/README.md
+++ b/embedding_quantization/README.md
@@ -24,16 +24,16 @@ All arrays use row-major layout. Quantized residuals are bit-packed: with `numBi
 
 ## Results
 
-On an NVIDIA T4 (SM75), with `numDocs=100K`, `numToScore=10K`, `embDim=1024`, `numBitsPerDim=2`, `numCentroids=1024`:
+On an NVIDIA T4 (SM75), with `numDocs=200K`, `numToScore=10K`, `embDim=4096`, `numBitsPerDim=2`, `numCentroids=1024`:
 
 | Method             | RMSE     | Latency  |
 |--------------------|----------|----------|
-| Baseline H2D       | 0.000    | 3.28 ms  |
-| Baseline D2D       | 0.000    | 0.64 ms  |
-| ResQuant H2D       | 0.107    | 1.14 ms  |
-| ResQuant D2D       | 0.107    | 1.00 ms  |
-| TurboQuant H2D     | 0.059    | 3.36 ms  |
-| TurboQuant D2D     | 0.059    | 2.52 ms  |
+| Baseline H2D       | 0.000    | 13.08 ms |
+| Baseline D2D       | 0.000    | 1.21 ms  |
+| ResQuant H2D       | 0.107    | 2.44 ms  |
+| ResQuant D2D       | 0.107    | 3.98 ms  |
+| TurboQuant H2D     | 0.059    | 12.73 ms |
+| TurboQuant D2D     | 0.059    | 9.99 ms  |
 
 RMSE is normalized per-document: `mean over docs of (‖reconstructed − original‖₂ / ‖original‖₂)`.
 

--- a/embedding_quantization/README.md
+++ b/embedding_quantization/README.md
@@ -24,16 +24,16 @@ All arrays use row-major layout. Quantized residuals are bit-packed: with `numBi
 
 ## Results
 
-On an NVIDIA T4 (SM75), with `numDocs=200K`, `numToScore=10K`, `embDim=4096`, `numBitsPerDim=2`, `numCentroids=1024`:
+On an NVIDIA T4 (SM75), with `numDocs=200K`, `numToScore=20K`, `embDim=4096`, `numBitsPerDim=2`, `numCentroids=1024`:
 
 | Method             | RMSE     | Latency  |
 |--------------------|----------|----------|
-| Baseline H2D       | 0.000    | 13.08 ms |
-| Baseline D2D       | 0.000    | 1.21 ms  |
-| ResQuant H2D       | 0.107    | 2.44 ms  |
-| ResQuant D2D       | 0.107    | 3.98 ms  |
-| TurboQuant H2D     | 0.059    | 12.73 ms |
-| TurboQuant D2D     | 0.059    | 9.99 ms  |
+| Baseline H2D       | 0.000    | 26.15 ms |
+| Baseline D2D       | 0.000    |  2.41 ms |
+| ResQuant H2D       | 0.107    |  9.14 ms |
+| ResQuant D2D       | 0.107    |  5.76 ms |
+| TurboQuant H2D     | 0.059    | 21.52 ms |
+| TurboQuant D2D     | 0.059    | 17.60 ms |
 
 RMSE is normalized per-document: `mean over docs of (‖reconstructed − original‖₂ / ‖original‖₂)`.
 

--- a/embedding_quantization/README.md
+++ b/embedding_quantization/README.md
@@ -1,0 +1,58 @@
+# Embedding Quantization
+
+A CUDA benchmark comparing methods for approximate nearest neighbor search via embedding quantization. Each method compresses document embeddings offline and reconstructs them at query time, trading reconstruction accuracy for memory bandwidth.
+
+## Methods
+
+### Baseline
+Stores full-precision (`bfloat16`) embeddings and copies them to the GPU at query time (H2D) or reads them directly from device memory (D2D). This is the reference for latency and zero reconstruction error.
+
+### Residual Quantization (ResQuant)
+Assigns each document to its nearest centroid and quantizes the residual (embedding − centroid) using a uniform scalar quantizer, packing 2 bits per dimension into `uint64_t` words.
+
+### TurboQuant ([paper](https://arxiv.org/abs/2504.19874))
+Applies a Randomized Hadamard Transform (RHT) to the residual before quantizing with a Lloyd-Max scalar quantizer tuned for Gaussian inputs. The RHT spreads quantization error uniformly across all dimensions, and Lloyd-Max centroids minimize MSE for the resulting near-Gaussian distribution — together they reduce RMSE by ~45% relative to ResQuant.
+
+The WHT kernel uses a three-tier butterfly strategy to minimize shared memory:
+- **Tier 1** (strides < `elemsPerThread`): pure register arithmetic
+- **Tier 2** (strides `elemsPerThread`..`31×elemsPerThread`): `__shfl_xor_sync` for intra-warp exchange
+- **Tier 3** (strides ≥ `32×elemsPerThread`): single shared memory buffer (half of ping-pong, doubling occupancy)
+
+## Data Layout
+
+All arrays use row-major layout. Quantized residuals are bit-packed: with `numBitsPerDim=2` and `RQ_T=uint64_t`, each 64-bit word holds 32 dimensions. The centroid value table is stored flat (`numCentroids × embDim`) for coalesced access.
+
+## Results
+
+On an NVIDIA T4 (SM75), with `numDocs=100K`, `numToScore=10K`, `embDim=1024`, `numBitsPerDim=2`, `numCentroids=1024`:
+
+| Method             | RMSE     | Latency  |
+|--------------------|----------|----------|
+| Baseline H2D       | 0.000    | 3.28 ms  |
+| Baseline D2D       | 0.000    | 0.64 ms  |
+| ResQuant H2D       | 0.107    | 1.14 ms  |
+| ResQuant D2D       | 0.107    | 1.00 ms  |
+| TurboQuant H2D     | 0.059    | 3.36 ms  |
+| TurboQuant D2D     | 0.059    | 2.52 ms  |
+
+RMSE is normalized per-document: `mean over docs of (‖reconstructed − original‖₂ / ‖original‖₂)`.
+
+## Build
+
+Requires CUDA, CMake ≥ 3.18, and OpenMP.
+
+```bash
+bash run.sh
+```
+
+Or manually:
+
+```bash
+mkdir build && cd build
+cmake ..
+make -j$(nproc)
+./test_embedding_quantization_unit_tests
+./test_embedding_quantization
+```
+
+Targets SM75 (T4), SM80 (A100), SM86, SM89 (RTX 4090), SM90 (H100).

--- a/embedding_quantization/include/data.cuh
+++ b/embedding_quantization/include/data.cuh
@@ -42,6 +42,10 @@ struct Data
     int*   d_centroidIdx;
     RQ_T*  h_residual; // numDocs x getRqDim(), packed quantized residuals for res_quant
     RQ_T*  d_residual;
+    float* h_centroidStd; // numCentroids x embDim, per-dim per-centroid stdDev for res_quant
+    float* d_centroidStd;
+    float* h_centroidEffStd; // numCentroids x 1, RMS effective stdDev per centroid for turbo_quant
+    float* d_centroidEffStd;
     int*   h_rhtSigns; // embDim x 1, random ±1 signs for RHT used by turbo_quant
     int*   d_rhtSigns;
     RQ_T*  h_turboRes; // numDocs x getRqDim(), Lloyd-Max quantized rotated residuals for turbo_quant

--- a/embedding_quantization/include/data.cuh
+++ b/embedding_quantization/include/data.cuh
@@ -41,8 +41,12 @@ struct Data
     EMB_T* d_centroidEmb;
     int*   h_centroidIdx; // numDocs x 1
     int*   d_centroidIdx;
-    RQ_T*  h_residual; // numDocs x embDim x numBitsPerDim / sizeof(RQ_T)
+    RQ_T*  h_residual; // numDocs x getRqDim(), packed quantized residuals for res_quant
     RQ_T*  d_residual;
+    int*   h_rhtSigns; // embDim x 1, random ±1 signs for RHT used by turbo_quant
+    int*   d_rhtSigns;
+    RQ_T*  h_turboRes; // numDocs x getRqDim(), Lloyd-Max quantized rotated residuals for turbo_quant
+    RQ_T*  d_turboRes;
     int*   h_docIdxToScore; // numToScore x 1
     int*   d_docIdxToScore;
     EMB_T* d_rst; // numToScore x embDim
@@ -164,6 +168,61 @@ inline void quantize(int   numBitsPerDim,
     // !!!!!VERY IMPORTANT!!!!! rq is NOT OVERWRITTEN-ABLE. Let's say you first encode 0b01, and then encode 0b10, the
     // result will be 0b11, NOT 0b10
     globalQuantRes |= mask;
+}
+
+// Lloyd-Max scalar quantizer for Gaussian N(0, stdDev²) at numBitsPerDim=2.
+// Boundaries at 0 and ±0.9816*stdDev; centroids at ±0.4528*stdDev and ±1.5104*stdDev.
+// Uses the same bit-packing layout as quantize/dequantize.
+inline void lloydMaxQuantize(int   numBitsPerDim,
+                             int   numBitsPerInt,
+                             float stdDev,
+                             float val,
+                             RQ_T& globalQuantRes,
+                             int   embIdx)
+{
+    int bin;
+    if (val < -0.9816f * stdDev)
+        bin = 0;
+    else if (val < 0.0f)
+        bin = 1;
+    else if (val < 0.9816f * stdDev)
+        bin = 2;
+    else
+        bin = 3;
+
+    const int embsPerInt = numBitsPerInt / numBitsPerDim;
+    const int shifts     = (embIdx % embsPerInt) * numBitsPerDim;
+    globalQuantRes |= static_cast<RQ_T>(bin) << shifts;
+}
+
+inline __device__ __host__ float lloydMaxDequantize(int   numBitsPerDim,
+                                                    int   numBitsPerInt,
+                                                    float stdDev,
+                                                    RQ_T  rq,
+                                                    int   embIdx)
+{
+    const int embsPerInt = numBitsPerInt / numBitsPerDim;
+    const int shifts     = (embIdx % embsPerInt) * numBitsPerDim;
+    const int fullRange  = (1 << numBitsPerDim);
+    int       bin        = static_cast<int>(((static_cast<RQ_T>(fullRange) - 1) << shifts & rq) >> shifts);
+
+    float centroid;
+    switch (bin)
+    {
+    case 0:
+        centroid = -1.5104f;
+        break;
+    case 1:
+        centroid = -0.4528f;
+        break;
+    case 2:
+        centroid = 0.4528f;
+        break;
+    default:
+        centroid = 1.5104f;
+        break;
+    }
+    return centroid * stdDev;
 }
 
 inline __device__ __host__ float dequantize(int numBitsPerDim, int numBitsPerInt, float stdDev, RQ_T rq, int embIdx)

--- a/embedding_quantization/include/data.cuh
+++ b/embedding_quantization/include/data.cuh
@@ -44,9 +44,8 @@ struct Data
     RQ_T*  d_residual;
     float* h_centroidStd; // numCentroids x embDim, per-dim per-centroid stdDev for res_quant
     float* d_centroidStd;
-    float* h_centroidEffStd; // numCentroids x 1, RMS effective stdDev per centroid for turbo_quant
-    float* d_centroidEffStd;
-    int*   h_rhtSigns; // embDim x 1, random ±1 signs for RHT used by turbo_quant
+    float  turboQuantStdDev; // global RMS stdDev of raw embeddings, for turbo_quant Lloyd-Max boundaries
+    int*   h_rhtSigns;       // embDim x 1, random ±1 signs for RHT used by turbo_quant
     int*   d_rhtSigns;
     RQ_T*  h_turboRes; // numDocs x getRqDim(), Lloyd-Max quantized rotated residuals for turbo_quant
     RQ_T*  d_turboRes;

--- a/embedding_quantization/include/data.cuh
+++ b/embedding_quantization/include/data.cuh
@@ -36,9 +36,8 @@ struct Data
 
     EMB_T* h_emb; // numDocs x embDim
     EMB_T* d_emb;
-    EMB_T*
-        h_centroidEmb; // numCentroids x embDim x 2 (the first half is the embedding, and the second half is the stdDev)
-    EMB_T* d_centroidEmb;
+    EMB_T* h_centroidVal; // numCentroids x embDim
+    EMB_T* d_centroidVal;
     int*   h_centroidIdx; // numDocs x 1
     int*   d_centroidIdx;
     RQ_T*  h_residual; // numDocs x getRqDim(), packed quantized residuals for res_quant

--- a/embedding_quantization/include/methods.cuh
+++ b/embedding_quantization/include/methods.cuh
@@ -4,11 +4,13 @@
 
 enum class Method
 {
-    REFERENCE     = 0,
-    BASELINE_H2D  = 1,
-    BASELINE_D2D  = 2,
-    RES_QUANT_H2D = 3,
-    RES_QUANT_D2D = 4
+    REFERENCE       = 0,
+    BASELINE_H2D    = 1,
+    BASELINE_D2D    = 2,
+    RES_QUANT_H2D   = 3,
+    RES_QUANT_D2D   = 4,
+    TURBO_QUANT_H2D = 5,
+    TURBO_QUANT_D2D = 6
 };
 
 void runMethod(Data data, Method method);

--- a/embedding_quantization/include/methods_turbo_quant.cuh
+++ b/embedding_quantization/include/methods_turbo_quant.cuh
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "data.cuh"
+
+void methodTurboQuant(Data data, bool copyTurboResFromHost);

--- a/embedding_quantization/include/methods_turbo_quant.cuh
+++ b/embedding_quantization/include/methods_turbo_quant.cuh
@@ -1,5 +1,7 @@
 #pragma once
 
+// TurboQuant: https://arxiv.org/abs/2504.19874
+
 #include "data.cuh"
 
 void methodTurboQuant(Data data, bool copyTurboResFromHost);

--- a/embedding_quantization/src/data.cu
+++ b/embedding_quantization/src/data.cu
@@ -25,8 +25,6 @@ Data genData(Config config)
         CHECK_CUDA(cudaMalloc(&data.d_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
         CHECK_CUDA(cudaMallocHost(&data.h_centroidStd, config.numCentroids * config.embDim * sizeof(float)));
         CHECK_CUDA(cudaMalloc(&data.d_centroidStd, config.numCentroids * config.embDim * sizeof(float)));
-        CHECK_CUDA(cudaMallocHost(&data.h_centroidEffStd, config.numCentroids * sizeof(float)));
-        CHECK_CUDA(cudaMalloc(&data.d_centroidEffStd, config.numCentroids * sizeof(float)));
         CHECK_CUDA(cudaMallocHost(&data.h_rhtSigns, config.embDim * sizeof(int)));
         CHECK_CUDA(cudaMalloc(&data.d_rhtSigns, config.embDim * sizeof(int)));
         CHECK_CUDA(cudaMallocHost(&data.h_turboRes, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
@@ -91,9 +89,8 @@ Data genData(Config config)
 }
 
 // ------------
-// Phase 2: compute per-dim per-centroid stdDev and per-centroid effective stdDev
-// centroidIdx = docIdx % numCentroids, so each centroid's docs are perfectly strided —
-// parallelize over centroids with no locking needed.
+// Phase 2: compute per-dim per-centroid stdDev (for res_quant) and global turboQuantStdDev.
+// centroidIdx = docIdx % numCentroids, so strided iteration over docs is race-free per centroid.
 {
     std::cout << "Computing per-centroid stdDev" << std::endl;
 #pragma omp parallel for schedule(dynamic)
@@ -113,66 +110,78 @@ Data genData(Config config)
                 sumSq[embIdx] += r * r;
             }
         }
-        double effVarSum = 0.0;
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+            data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]
+                = static_cast<float>(std::sqrt(sumSq[embIdx] / cnt));
+    }
+
+    // turboQuantStdDev = RMS of raw embedding values across all docs and dims.
+    // Computed cheaply from centroid means and per-dim residual variances:
+    //   E[emb²] = E[(centroid + residual)²] = centroid² + residual_var  (cross term is zero)
+    // Averaged uniformly across all centroids (valid since numDocs/numCentroids is constant).
+    double sumSqTotal = 0.0;
+    for (int centroidIdx = 0; centroidIdx < (int)config.numCentroids; centroidIdx++)
         for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
         {
-            double var = sumSq[embIdx] / cnt;
-            data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]
-                = static_cast<float>(std::sqrt(var));
-            effVarSum += var;
+            float cv = static_cast<float>(
+                data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]);
+            float cs = data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)];
+            sumSqTotal += (double)cv * cv + (double)cs * cs;
         }
-        // Effective stdDev for TurboQuant: RMS of per-dim stdDevs.
-        // After RHT, rotated residuals have variance = mean of per-dim variances.
-        data.h_centroidEffStd[centroidIdx] = static_cast<float>(std::sqrt(effVarSum / config.embDim));
-    }
+    data.turboQuantStdDev = static_cast<float>(std::sqrt(sumSqTotal / ((double)config.numCentroids * config.embDim)));
 }
 
 // ------------
-// Phase 3: quantize residuals using computed stdDevs
+// Phase 3: quantize residuals
 {
     std::cout << "Quantizing residuals" << std::endl;
     int numThreads = omp_get_max_threads();
 #pragma omp parallel for num_threads(numThreads) schedule(static)
     for (size_t docIdx = 0; docIdx < config.numDocs; docIdx++)
     {
-        int   centroidIdx = data.h_centroidIdx[docIdx];
-        float effStd      = data.h_centroidEffStd[centroidIdx];
+        int centroidIdx = data.h_centroidIdx[docIdx];
 
-        std::vector<float> residuals(config.embDim);
+        // ResQuant: quantize residual (emb - centroid) with per-dim per-centroid stdDev
         for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
         {
             float emb      = static_cast<float>(data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)]);
             float centroid = static_cast<float>(
                 data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]);
-            float residual    = emb - centroid;
-            residuals[embIdx] = residual;
-
-            // ResQuant: per-dim per-centroid stdDev
+            float residual  = emb - centroid;
             float std       = data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)];
             auto  rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
             auto  rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
             quantize(config.numBitsPerDim, kBitsPerInt, std, residual, data.h_residual[rqMemAddr], embIdx);
         }
 
-        // TurboQuant: RHT then lloydMaxQuantize with per-centroid effective stdDev
+        // TurboQuant: apply RHT to the raw embedding (no centroid subtraction),
+        // then lloydMaxQuantize with the global turboQuantStdDev.
+        std::vector<float> embs(config.embDim);
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+            embs[embIdx] = static_cast<float>(data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)]);
         for (int i = 0; i < (int)config.embDim; i++)
-            residuals[i] *= data.h_rhtSigns[i];
+            embs[i] *= data.h_rhtSigns[i];
         for (int stride = 1; stride < (int)config.embDim; stride <<= 1)
             for (int i = 0; i < (int)config.embDim; i += 2 * stride)
                 for (int j = 0; j < stride; j++)
                 {
-                    float a                   = residuals[i + j];
-                    float b                   = residuals[i + j + stride];
-                    residuals[i + j]          = a + b;
-                    residuals[i + j + stride] = a - b;
+                    float a              = embs[i + j];
+                    float b              = embs[i + j + stride];
+                    embs[i + j]          = a + b;
+                    embs[i + j + stride] = a - b;
                 }
         float scale = 1.0f / sqrtf((float)config.embDim);
         for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
         {
-            float rotated   = residuals[embIdx] * scale;
+            float rotated   = embs[embIdx] * scale;
             auto  rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
             auto  rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
-            lloydMaxQuantize(config.numBitsPerDim, kBitsPerInt, effStd, rotated, data.h_turboRes[rqMemAddr], embIdx);
+            lloydMaxQuantize(config.numBitsPerDim,
+                             kBitsPerInt,
+                             data.turboQuantStdDev,
+                             rotated,
+                             data.h_turboRes[rqMemAddr],
+                             embIdx);
         }
     }
 }
@@ -212,10 +221,6 @@ Data genData(Config config)
     CHECK_CUDA(cudaMemcpy(data.d_centroidStd,
                           data.h_centroidStd,
                           config.numCentroids * config.embDim * sizeof(float),
-                          cudaMemcpyHostToDevice));
-    CHECK_CUDA(cudaMemcpy(data.d_centroidEffStd,
-                          data.h_centroidEffStd,
-                          config.numCentroids * sizeof(float),
                           cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_rhtSigns, data.h_rhtSigns, config.embDim * sizeof(int), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_turboRes,

--- a/embedding_quantization/src/data.cu
+++ b/embedding_quantization/src/data.cu
@@ -22,9 +22,14 @@ Data genData(Config config)
         CHECK_CUDA(cudaMalloc(&data.d_centroidIdx, config.numDocs * sizeof(int)));
         CHECK_CUDA(cudaMallocHost(&data.h_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
         memset(data.h_residual, 0, config.numDocs * config.getRqDim() * sizeof(RQ_T));
+        CHECK_CUDA(cudaMalloc(&data.d_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
+        CHECK_CUDA(cudaMallocHost(&data.h_rhtSigns, config.embDim * sizeof(int)));
+        CHECK_CUDA(cudaMalloc(&data.d_rhtSigns, config.embDim * sizeof(int)));
+        CHECK_CUDA(cudaMallocHost(&data.h_turboRes, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
+        memset(data.h_turboRes, 0, config.numDocs * config.getRqDim() * sizeof(RQ_T));
+        CHECK_CUDA(cudaMalloc(&data.d_turboRes, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
         CHECK_CUDA(cudaMallocHost(&data.h_docIdxToScore, config.numToScore * sizeof(int)));
         CHECK_CUDA(cudaMalloc(&data.d_docIdxToScore, config.numToScore * sizeof(int)));
-        CHECK_CUDA(cudaMalloc(&data.d_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
         CHECK_CUDA(cudaMalloc(&data.d_rst, config.numToScore * config.embDim * sizeof(EMB_T)));
     }
 
@@ -47,6 +52,16 @@ Data genData(Config config)
 }
 
 // ------------
+// Generate RHT signs for turbo_quant
+{
+    std::cout << "Generating RHT signs" << std::endl;
+    std::default_random_engine         rhtRng(42);
+    std::uniform_int_distribution<int> signDist(0, 1);
+    for (int i = 0; i < config.embDim; i++)
+        data.h_rhtSigns[i] = (signDist(rhtRng) == 0) ? -1 : 1;
+}
+
+// ------------
 // Generate document embeddings
 {
     std::cout << "Generating document embeddings" << std::endl;
@@ -64,18 +79,50 @@ Data genData(Config config)
     {
         int centroidIdx            = docIdx % config.numCentroids;
         data.h_centroidIdx[docIdx] = centroidIdx;
+
+        // Collect all residuals for this document so we can apply RHT afterward
+        std::vector<float> residuals(config.embDim);
+
         for (int embIdx = 0; embIdx < config.embDim; embIdx++)
         {
             auto centroid
                 = data.h_centroidEmb[getMemAddr(centroidIdx, embIdx * 2, config.numCentroids, config.embDim * 2)];
-            auto  residual = norm_distributions[omp_get_thread_num()](generators[omp_get_thread_num()]);
-            float emb
-                = static_cast<float>(centroid)
-                  + residual; // We use float here because some compilers can't perform the addition of BF16 in CPU
+            float residual = norm_distributions[omp_get_thread_num()](generators[omp_get_thread_num()]);
+            float emb      = static_cast<float>(centroid) + residual;
             data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)] = static_cast<EMB_T>(emb);
             auto rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
             auto rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
             quantize(config.numBitsPerDim, kBitsPerInt, config.stdDev, residual, data.h_residual[rqMemAddr], embIdx);
+            residuals[embIdx] = residual;
+        }
+
+        // Apply RHT to residuals: x_rot = (1/sqrt(d)) * WHT(signs * x)
+        // Step 1: sign flip
+        for (int i = 0; i < config.embDim; i++)
+            residuals[i] *= data.h_rhtSigns[i];
+        // Step 2: Walsh-Hadamard Transform (in-place)
+        for (int stride = 1; stride < config.embDim; stride <<= 1)
+            for (int i = 0; i < config.embDim; i += 2 * stride)
+                for (int j = 0; j < stride; j++)
+                {
+                    float a                   = residuals[i + j];
+                    float b                   = residuals[i + j + stride];
+                    residuals[i + j]          = a + b;
+                    residuals[i + j + stride] = a - b;
+                }
+        // Step 3: normalize and Lloyd-Max quantize
+        float scale = 1.0f / sqrtf((float)config.embDim);
+        for (int embIdx = 0; embIdx < config.embDim; embIdx++)
+        {
+            float rotated   = residuals[embIdx] * scale;
+            auto  rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
+            auto  rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
+            lloydMaxQuantize(config.numBitsPerDim,
+                             kBitsPerInt,
+                             config.stdDev,
+                             rotated,
+                             data.h_turboRes[rqMemAddr],
+                             embIdx);
         }
     }
 }
@@ -114,6 +161,11 @@ Data genData(Config config)
         cudaMemcpy(data.d_centroidIdx, data.h_centroidIdx, config.numDocs * sizeof(int), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_residual,
                           data.h_residual,
+                          config.numDocs * config.getRqDim() * sizeof(RQ_T),
+                          cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(data.d_rhtSigns, data.h_rhtSigns, config.embDim * sizeof(int), cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(data.d_turboRes,
+                          data.h_turboRes,
                           config.numDocs * config.getRqDim() * sizeof(RQ_T),
                           cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_docIdxToScore,

--- a/embedding_quantization/src/data.cu
+++ b/embedding_quantization/src/data.cu
@@ -16,8 +16,8 @@ Data genData(Config config)
         std::cout << "Allocating memory for data" << std::endl;
         CHECK_CUDA(cudaMallocHost(&data.h_emb, config.numDocs * config.embDim * sizeof(EMB_T)));
         CHECK_CUDA(cudaMalloc(&data.d_emb, config.numDocs * config.embDim * sizeof(EMB_T)));
-        CHECK_CUDA(cudaMallocHost(&data.h_centroidEmb, config.numCentroids * config.embDim * 2 * sizeof(EMB_T)));
-        CHECK_CUDA(cudaMalloc(&data.d_centroidEmb, config.numCentroids * config.embDim * 2 * sizeof(EMB_T)));
+        CHECK_CUDA(cudaMallocHost(&data.h_centroidVal, config.numCentroids * config.embDim * sizeof(EMB_T)));
+        CHECK_CUDA(cudaMalloc(&data.d_centroidVal, config.numCentroids * config.embDim * sizeof(EMB_T)));
         CHECK_CUDA(cudaMallocHost(&data.h_centroidIdx, config.numDocs * sizeof(int)));
         CHECK_CUDA(cudaMalloc(&data.d_centroidIdx, config.numDocs * sizeof(int)));
         CHECK_CUDA(cudaMallocHost(&data.h_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
@@ -44,9 +44,8 @@ Data genData(Config config)
     {
         for (int embIdx = 0; embIdx < config.embDim; embIdx++)
         {
-            const auto addr              = getMemAddr(centroidIdx, embIdx * 2, config.numCentroids, config.embDim * 2);
-            data.h_centroidEmb[addr]     = (EMB_T)distribution(generator);
-            data.h_centroidEmb[addr + 1] = (EMB_T)config.stdDev;
+            const auto addr          = getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim);
+            data.h_centroidVal[addr] = (EMB_T)distribution(generator);
         }
     }
 }
@@ -85,8 +84,7 @@ Data genData(Config config)
 
         for (int embIdx = 0; embIdx < config.embDim; embIdx++)
         {
-            auto centroid
-                = data.h_centroidEmb[getMemAddr(centroidIdx, embIdx * 2, config.numCentroids, config.embDim * 2)];
+            auto  centroid = data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)];
             float residual = norm_distributions[omp_get_thread_num()](generators[omp_get_thread_num()]);
             float emb      = static_cast<float>(centroid) + residual;
             data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)] = static_cast<EMB_T>(emb);
@@ -133,17 +131,13 @@ Data genData(Config config)
     std::cout << "Generating document indices to score" << std::endl;
     std::vector<int> docIdxToScore(config.numDocs);
     for (int i = 0; i < config.numDocs; i++)
-    {
         docIdxToScore[i] = i;
-    }
     std::default_random_engine generator;
     std::shuffle(docIdxToScore.begin(), docIdxToScore.end(), generator);
     docIdxToScore.resize(config.numToScore);
     std::sort(docIdxToScore.begin(), docIdxToScore.end());
     for (int i = 0; i < config.numToScore; i++)
-    {
         data.h_docIdxToScore[i] = docIdxToScore[i];
-    }
 }
 }
 
@@ -153,9 +147,9 @@ Data genData(Config config)
     std::cout << "Copying data to device" << std::endl;
     CHECK_CUDA(
         cudaMemcpy(data.d_emb, data.h_emb, config.numDocs * config.embDim * sizeof(EMB_T), cudaMemcpyHostToDevice));
-    CHECK_CUDA(cudaMemcpy(data.d_centroidEmb,
-                          data.h_centroidEmb,
-                          config.numCentroids * config.embDim * 2 * sizeof(EMB_T),
+    CHECK_CUDA(cudaMemcpy(data.d_centroidVal,
+                          data.h_centroidVal,
+                          config.numCentroids * config.embDim * sizeof(EMB_T),
                           cudaMemcpyHostToDevice));
     CHECK_CUDA(
         cudaMemcpy(data.d_centroidIdx, data.h_centroidIdx, config.numDocs * sizeof(int), cudaMemcpyHostToDevice));

--- a/embedding_quantization/src/data.cu
+++ b/embedding_quantization/src/data.cu
@@ -23,6 +23,10 @@ Data genData(Config config)
         CHECK_CUDA(cudaMallocHost(&data.h_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
         memset(data.h_residual, 0, config.numDocs * config.getRqDim() * sizeof(RQ_T));
         CHECK_CUDA(cudaMalloc(&data.d_residual, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
+        CHECK_CUDA(cudaMallocHost(&data.h_centroidStd, config.numCentroids * config.embDim * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&data.d_centroidStd, config.numCentroids * config.embDim * sizeof(float)));
+        CHECK_CUDA(cudaMallocHost(&data.h_centroidEffStd, config.numCentroids * sizeof(float)));
+        CHECK_CUDA(cudaMalloc(&data.d_centroidEffStd, config.numCentroids * sizeof(float)));
         CHECK_CUDA(cudaMallocHost(&data.h_rhtSigns, config.embDim * sizeof(int)));
         CHECK_CUDA(cudaMalloc(&data.d_rhtSigns, config.embDim * sizeof(int)));
         CHECK_CUDA(cudaMallocHost(&data.h_turboRes, config.numDocs * config.getRqDim() * sizeof(RQ_T)));
@@ -40,14 +44,10 @@ Data genData(Config config)
       { std::cout << "Generating centroid embeddings" << std::endl;
     std::default_random_engine            generator;
     std::uniform_real_distribution<float> distribution(-1.0, 1.0);
-    for (int centroidIdx = 0; centroidIdx < config.numCentroids; centroidIdx++)
-    {
-        for (int embIdx = 0; embIdx < config.embDim; embIdx++)
-        {
-            const auto addr          = getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim);
-            data.h_centroidVal[addr] = (EMB_T)distribution(generator);
-        }
-    }
+    for (int centroidIdx = 0; centroidIdx < (int)config.numCentroids; centroidIdx++)
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+            data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]
+                = (EMB_T)distribution(generator);
 }
 
 // ------------
@@ -56,12 +56,12 @@ Data genData(Config config)
     std::cout << "Generating RHT signs" << std::endl;
     std::default_random_engine         rhtRng(42);
     std::uniform_int_distribution<int> signDist(0, 1);
-    for (int i = 0; i < config.embDim; i++)
+    for (int i = 0; i < (int)config.embDim; i++)
         data.h_rhtSigns[i] = (signDist(rhtRng) == 0) ? -1 : 1;
 }
 
 // ------------
-// Generate document embeddings
+// Phase 1: generate document embeddings (no quantization yet)
 {
     std::cout << "Generating document embeddings" << std::endl;
     int                                          numThreads = omp_get_max_threads();
@@ -78,29 +78,87 @@ Data genData(Config config)
     {
         int centroidIdx            = docIdx % config.numCentroids;
         data.h_centroidIdx[docIdx] = centroidIdx;
-
-        // Collect all residuals for this document so we can apply RHT afterward
-        std::vector<float> residuals(config.embDim);
-
-        for (int embIdx = 0; embIdx < config.embDim; embIdx++)
+        int tid                    = omp_get_thread_num();
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
         {
-            auto  centroid = data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)];
-            float residual = norm_distributions[omp_get_thread_num()](generators[omp_get_thread_num()]);
-            float emb      = static_cast<float>(centroid) + residual;
-            data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)] = static_cast<EMB_T>(emb);
-            auto rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
-            auto rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
-            quantize(config.numBitsPerDim, kBitsPerInt, config.stdDev, residual, data.h_residual[rqMemAddr], embIdx);
+            float centroid = static_cast<float>(
+                data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]);
+            float residual = norm_distributions[tid](generators[tid]);
+            data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)]
+                = static_cast<EMB_T>(centroid + residual);
+        }
+    }
+}
+
+// ------------
+// Phase 2: compute per-dim per-centroid stdDev and per-centroid effective stdDev
+// centroidIdx = docIdx % numCentroids, so each centroid's docs are perfectly strided —
+// parallelize over centroids with no locking needed.
+{
+    std::cout << "Computing per-centroid stdDev" << std::endl;
+#pragma omp parallel for schedule(dynamic)
+    for (int centroidIdx = 0; centroidIdx < (int)config.numCentroids; centroidIdx++)
+    {
+        int                 cnt = 0;
+        std::vector<double> sumSq(config.embDim, 0.0);
+        for (size_t docIdx = centroidIdx; docIdx < config.numDocs; docIdx += config.numCentroids)
+        {
+            cnt++;
+            for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+            {
+                float emb = static_cast<float>(data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)]);
+                float centroid = static_cast<float>(
+                    data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]);
+                double r = emb - centroid;
+                sumSq[embIdx] += r * r;
+            }
+        }
+        double effVarSum = 0.0;
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+        {
+            double var = sumSq[embIdx] / cnt;
+            data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]
+                = static_cast<float>(std::sqrt(var));
+            effVarSum += var;
+        }
+        // Effective stdDev for TurboQuant: RMS of per-dim stdDevs.
+        // After RHT, rotated residuals have variance = mean of per-dim variances.
+        data.h_centroidEffStd[centroidIdx] = static_cast<float>(std::sqrt(effVarSum / config.embDim));
+    }
+}
+
+// ------------
+// Phase 3: quantize residuals using computed stdDevs
+{
+    std::cout << "Quantizing residuals" << std::endl;
+    int numThreads = omp_get_max_threads();
+#pragma omp parallel for num_threads(numThreads) schedule(static)
+    for (size_t docIdx = 0; docIdx < config.numDocs; docIdx++)
+    {
+        int   centroidIdx = data.h_centroidIdx[docIdx];
+        float effStd      = data.h_centroidEffStd[centroidIdx];
+
+        std::vector<float> residuals(config.embDim);
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
+        {
+            float emb      = static_cast<float>(data.h_emb[getMemAddr(docIdx, embIdx, config.numDocs, config.embDim)]);
+            float centroid = static_cast<float>(
+                data.h_centroidVal[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)]);
+            float residual    = emb - centroid;
             residuals[embIdx] = residual;
+
+            // ResQuant: per-dim per-centroid stdDev
+            float std       = data.h_centroidStd[getMemAddr(centroidIdx, embIdx, config.numCentroids, config.embDim)];
+            auto  rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
+            auto  rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
+            quantize(config.numBitsPerDim, kBitsPerInt, std, residual, data.h_residual[rqMemAddr], embIdx);
         }
 
-        // Apply RHT to residuals: x_rot = (1/sqrt(d)) * WHT(signs * x)
-        // Step 1: sign flip
-        for (int i = 0; i < config.embDim; i++)
+        // TurboQuant: RHT then lloydMaxQuantize with per-centroid effective stdDev
+        for (int i = 0; i < (int)config.embDim; i++)
             residuals[i] *= data.h_rhtSigns[i];
-        // Step 2: Walsh-Hadamard Transform (in-place)
-        for (int stride = 1; stride < config.embDim; stride <<= 1)
-            for (int i = 0; i < config.embDim; i += 2 * stride)
+        for (int stride = 1; stride < (int)config.embDim; stride <<= 1)
+            for (int i = 0; i < (int)config.embDim; i += 2 * stride)
                 for (int j = 0; j < stride; j++)
                 {
                     float a                   = residuals[i + j];
@@ -108,19 +166,13 @@ Data genData(Config config)
                     residuals[i + j]          = a + b;
                     residuals[i + j + stride] = a - b;
                 }
-        // Step 3: normalize and Lloyd-Max quantize
         float scale = 1.0f / sqrtf((float)config.embDim);
-        for (int embIdx = 0; embIdx < config.embDim; embIdx++)
+        for (int embIdx = 0; embIdx < (int)config.embDim; embIdx++)
         {
             float rotated   = residuals[embIdx] * scale;
             auto  rqIdx     = getRqIdx(embIdx, config.numBitsPerDim, kBitsPerInt);
             auto  rqMemAddr = getMemAddr(docIdx, rqIdx, config.numDocs, config.getRqDim());
-            lloydMaxQuantize(config.numBitsPerDim,
-                             kBitsPerInt,
-                             config.stdDev,
-                             rotated,
-                             data.h_turboRes[rqMemAddr],
-                             embIdx);
+            lloydMaxQuantize(config.numBitsPerDim, kBitsPerInt, effStd, rotated, data.h_turboRes[rqMemAddr], embIdx);
         }
     }
 }
@@ -130,13 +182,13 @@ Data genData(Config config)
 {
     std::cout << "Generating document indices to score" << std::endl;
     std::vector<int> docIdxToScore(config.numDocs);
-    for (int i = 0; i < config.numDocs; i++)
+    for (int i = 0; i < (int)config.numDocs; i++)
         docIdxToScore[i] = i;
     std::default_random_engine generator;
     std::shuffle(docIdxToScore.begin(), docIdxToScore.end(), generator);
     docIdxToScore.resize(config.numToScore);
     std::sort(docIdxToScore.begin(), docIdxToScore.end());
-    for (int i = 0; i < config.numToScore; i++)
+    for (int i = 0; i < (int)config.numToScore; i++)
         data.h_docIdxToScore[i] = docIdxToScore[i];
 }
 }
@@ -156,6 +208,14 @@ Data genData(Config config)
     CHECK_CUDA(cudaMemcpy(data.d_residual,
                           data.h_residual,
                           config.numDocs * config.getRqDim() * sizeof(RQ_T),
+                          cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(data.d_centroidStd,
+                          data.h_centroidStd,
+                          config.numCentroids * config.embDim * sizeof(float),
+                          cudaMemcpyHostToDevice));
+    CHECK_CUDA(cudaMemcpy(data.d_centroidEffStd,
+                          data.h_centroidEffStd,
+                          config.numCentroids * sizeof(float),
                           cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_rhtSigns, data.h_rhtSigns, config.embDim * sizeof(int), cudaMemcpyHostToDevice));
     CHECK_CUDA(cudaMemcpy(data.d_turboRes,

--- a/embedding_quantization/src/methods.cu
+++ b/embedding_quantization/src/methods.cu
@@ -2,6 +2,7 @@
 #include "methods.cuh"
 #include "methods_baseline.cuh"
 #include "methods_res_quant.cuh"
+#include "methods_turbo_quant.cuh"
 #include "util.cuh"
 #include <vector>
 
@@ -43,6 +44,12 @@ void runMethod(Data data, Method method)
         break;
     case Method::RES_QUANT_D2D:
         methodResQuant(data, false);
+        break;
+    case Method::TURBO_QUANT_H2D:
+        methodTurboQuant(data, true);
+        break;
+    case Method::TURBO_QUANT_D2D:
+        methodTurboQuant(data, false);
         break;
     default:
         throw std::runtime_error("Invalid method");

--- a/embedding_quantization/src/methods_res_quant.cu
+++ b/embedding_quantization/src/methods_res_quant.cu
@@ -20,16 +20,15 @@ __global__ void resQuantKernel(Data data, RQ_T* p_quantRes)
         int centroidIdx = data.d_centroidIdx[docIdx];
 
         // get the memory address of the centroid and quantized residual
-        size_t centroidMemAddr = getMemAddr(centroidIdx, embIdx * 2, data.config.numCentroids, data.config.embDim * 2);
+        size_t centroidMemAddr = getMemAddr(centroidIdx, embIdx, data.config.numCentroids, data.config.embDim);
         size_t quantResMemAddr = getMemAddr(docIdx, quantResIdx, data.config.numDocs, data.config.getRqDim());
 
-        // get the centroid, stdDev, and quantized residual
-        EMB_T centroid = data.d_centroidEmb[centroidMemAddr];
-        EMB_T stdDev   = data.d_centroidEmb[centroidMemAddr + 1];
+        // get the centroid and quantized residual
+        EMB_T centroid = data.d_centroidVal[centroidMemAddr];
         RQ_T  quantRes = p_quantRes[quantResMemAddr];
 
         // perform the dequantization
-        EMB_T residual = dequantize(data.config.numBitsPerDim, kBitsPerInt, stdDev, quantRes, embIdx);
+        EMB_T residual = dequantize(data.config.numBitsPerDim, kBitsPerInt, data.config.stdDev, quantRes, embIdx);
 
         // recover the embedding value by adding the centroid and the residual
         EMB_T rst = centroid + residual;

--- a/embedding_quantization/src/methods_res_quant.cu
+++ b/embedding_quantization/src/methods_res_quant.cu
@@ -23,12 +23,13 @@ __global__ void resQuantKernel(Data data, RQ_T* p_quantRes)
         size_t centroidMemAddr = getMemAddr(centroidIdx, embIdx, data.config.numCentroids, data.config.embDim);
         size_t quantResMemAddr = getMemAddr(docIdx, quantResIdx, data.config.numDocs, data.config.getRqDim());
 
-        // get the centroid and quantized residual
+        // get the centroid, per-dim stdDev, and quantized residual
         EMB_T centroid = data.d_centroidVal[centroidMemAddr];
+        float stdDev   = data.d_centroidStd[centroidMemAddr];
         RQ_T  quantRes = p_quantRes[quantResMemAddr];
 
         // perform the dequantization
-        EMB_T residual = dequantize(data.config.numBitsPerDim, kBitsPerInt, data.config.stdDev, quantRes, embIdx);
+        EMB_T residual = dequantize(data.config.numBitsPerDim, kBitsPerInt, stdDev, quantRes, embIdx);
 
         // recover the embedding value by adding the centroid and the residual
         EMB_T rst = centroid + residual;

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -3,31 +3,32 @@
 #include "util.cuh"
 
 // One block per scored document, 1024 threads per block.
-// Each thread handles kElemsPerThread=4 elements (assumes embDim=4096).
+// elemsPerThread = embDim / 1024 (e.g. 1 for embDim=1024, 4 for embDim=4096).
 //
 // WHT butterfly is split into three tiers to minimize shared memory pressure:
-//   - Strides 1, 2        (< kElemsPerThread):     intra-thread, pure register ops
-//   - Strides 4 .. 64     (intra-warp):             __shfl_xor_sync, no shared memory
-//   - Strides 128 .. 2048 (inter-warp):             single shared memory buffer (16 KB)
+//   - Strides < elemsPerThread:                intra-thread, pure register ops
+//   - Strides elemsPerThread .. 16*elemsPerThread (intra-warp): __shfl_xor_sync
+//   - Strides 32*elemsPerThread .. embDim/2    (inter-warp):   single shared memory buffer
 //
-// Using a single buffer (vs ping-pong) halves shared memory from 32 KB to 16 KB,
-// doubling occupancy from 4 to 8 blocks per SM.
+// Using a single buffer (vs ping-pong) halves shared memory, doubling occupancy.
+
+constexpr int kMaxElemsPerThread = 4; // upper bound; actual value is embDim / 1024
+
 __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
 {
-    constexpr int kElemsPerThread = 4;
-
     int toScoreIdx = blockIdx.x;
     if (toScoreIdx >= data.config.numToScore)
         return;
 
-    int docIdx = data.d_docIdxToScore[toScoreIdx];
-    int embDim = data.config.embDim;
+    int docIdx         = data.d_docIdxToScore[toScoreIdx];
+    int embDim         = data.config.embDim;
+    int elemsPerThread = embDim / blockDim.x;
 
     // Step 1: Lloyd-Max dequantize into registers (rotated space)
-    float vals[kElemsPerThread];
-    for (int k = 0; k < kElemsPerThread; k++)
+    float vals[kMaxElemsPerThread];
+    for (int k = 0; k < elemsPerThread; k++)
     {
-        int    embIdx    = threadIdx.x * kElemsPerThread + k;
+        int    embIdx    = threadIdx.x * elemsPerThread + k;
         int    rqIdx     = getRqIdx(embIdx, data.config.numBitsPerDim, kBitsPerInt);
         size_t rqMemAddr = getMemAddr(docIdx, rqIdx, data.config.numDocs, data.config.getRqDim());
         vals[k]          = lloydMaxDequantize(data.config.numBitsPerDim,
@@ -39,57 +40,49 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
 
     // Step 2: WHT butterfly — inverse RHT = (1/sqrt(d)) * D * WHT(x_rot)
 
-    // Tier 1: strides 1, 2 — pairs lie within the same thread's 4 elements, no sync needed
+    // Tier 1: strides 1..(elemsPerThread-1) — pairs within this thread's elements
+    for (int stride = 1; stride < elemsPerThread; stride <<= 1)
     {
-        float a;
-        a       = vals[0];
-        vals[0] = a + vals[1];
-        vals[1] = a - vals[1];
-        a       = vals[2];
-        vals[2] = a + vals[3];
-        vals[3] = a - vals[3];
-        a       = vals[0];
-        vals[0] = a + vals[2];
-        vals[2] = a - vals[2];
-        a       = vals[1];
-        vals[1] = a + vals[3];
-        vals[3] = a - vals[3];
+        float tmp[kMaxElemsPerThread];
+        for (int k = 0; k < elemsPerThread; k++)
+            tmp[k] = vals[k];
+        for (int k = 0; k < elemsPerThread; k++)
+            vals[k] = (k & stride) ? (tmp[k ^ stride] - tmp[k]) : (tmp[k] + tmp[k ^ stride]);
     }
 
-    // Tier 2: strides 4..64 — pairs within the same warp, use warp shuffles
-    for (int stride = kElemsPerThread; stride < kElemsPerThread * 32; stride <<= 1)
+    // Tier 2: strides elemsPerThread..16*elemsPerThread — intra-warp, use warp shuffles
+    for (int stride = elemsPerThread; stride < elemsPerThread * 32; stride <<= 1)
     {
-        int laneMask = stride / kElemsPerThread;
-        for (int k = 0; k < kElemsPerThread; k++)
+        int laneMask = stride / elemsPerThread;
+        for (int k = 0; k < elemsPerThread; k++)
         {
-            int   globalIdx = threadIdx.x * kElemsPerThread + k;
+            int   globalIdx = threadIdx.x * elemsPerThread + k;
             float partner   = __shfl_xor_sync(0xffffffff, vals[k], laneMask);
             vals[k]         = (globalIdx & stride) ? (partner - vals[k]) : (vals[k] + partner);
         }
     }
 
-    // Tier 3: strides 128..2048 — inter-warp, single shared memory buffer (16 KB)
+    // Tier 3: strides 32*elemsPerThread..embDim/2 — inter-warp, single shared memory buffer
     extern __shared__ float shm[]; // embDim floats
 
-    for (int k = 0; k < kElemsPerThread; k++)
-        shm[threadIdx.x * kElemsPerThread + k] = vals[k];
+    for (int k = 0; k < elemsPerThread; k++)
+        shm[threadIdx.x * elemsPerThread + k] = vals[k];
     __syncthreads();
 
-    for (int stride = kElemsPerThread * 32; stride < embDim; stride <<= 1)
+    for (int stride = elemsPerThread * 32; stride < embDim; stride <<= 1)
     {
-        for (int k = 0; k < kElemsPerThread; k++)
+        for (int k = 0; k < elemsPerThread; k++)
         {
-            int   globalIdx  = threadIdx.x * kElemsPerThread + k;
+            int   globalIdx  = threadIdx.x * elemsPerThread + k;
             float localVal   = shm[globalIdx];
             float partnerVal = shm[globalIdx ^ stride];
             vals[k]          = (globalIdx & stride) ? (partnerVal - localVal) : (localVal + partnerVal);
         }
         __syncthreads();
-        // Skip the write-back on the last stride — vals[] already holds the final result
         if (stride < embDim / 2)
         {
-            for (int k = 0; k < kElemsPerThread; k++)
-                shm[threadIdx.x * kElemsPerThread + k] = vals[k];
+            for (int k = 0; k < elemsPerThread; k++)
+                shm[threadIdx.x * elemsPerThread + k] = vals[k];
             __syncthreads();
         }
     }
@@ -97,9 +90,9 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
     // Step 3: sign flip, normalize, add centroid, store
     int   centroidIdx = data.d_centroidIdx[docIdx];
     float scale       = 1.0f / sqrtf((float)embDim);
-    for (int k = 0; k < kElemsPerThread; k++)
+    for (int k = 0; k < elemsPerThread; k++)
     {
-        int    embIdx          = threadIdx.x * kElemsPerThread + k;
+        int    embIdx          = threadIdx.x * elemsPerThread + k;
         float  residual        = vals[k] * scale * data.d_rhtSigns[embIdx];
         size_t centroidAddr    = getMemAddr(centroidIdx, embIdx, data.config.numCentroids, data.config.embDim);
         float  centroid        = static_cast<float>(data.d_centroidVal[centroidAddr]);
@@ -111,7 +104,7 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
 void methodTurboQuant(Data data, bool copyTurboResFromHost)
 {
     RQ_T*  p_turboRes = copyTurboResFromHost ? data.h_turboRes : data.d_turboRes;
-    size_t shmBytes   = data.config.embDim * sizeof(float); // single buffer, 16 KB for embDim=4096
+    size_t shmBytes   = data.config.embDim * sizeof(float);
     turboQuantKernel<<<data.config.numToScore, 1024, shmBytes>>>(data, p_turboRes);
     CHECK_CUDA(cudaGetLastError());
     CHECK_CUDA(cudaDeviceSynchronize());

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -20,9 +20,11 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
     if (toScoreIdx >= data.config.numToScore)
         return;
 
-    int docIdx         = data.d_docIdxToScore[toScoreIdx];
-    int embDim         = data.config.embDim;
-    int elemsPerThread = embDim / blockDim.x;
+    int   docIdx         = data.d_docIdxToScore[toScoreIdx];
+    int   centroidIdx    = data.d_centroidIdx[docIdx];
+    int   embDim         = data.config.embDim;
+    int   elemsPerThread = embDim / blockDim.x;
+    float effStd         = data.d_centroidEffStd[centroidIdx];
 
     // Step 1: Lloyd-Max dequantize into registers (rotated space)
     float vals[kMaxElemsPerThread];
@@ -31,11 +33,7 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
         int    embIdx    = threadIdx.x * elemsPerThread + k;
         int    rqIdx     = getRqIdx(embIdx, data.config.numBitsPerDim, kBitsPerInt);
         size_t rqMemAddr = getMemAddr(docIdx, rqIdx, data.config.numDocs, data.config.getRqDim());
-        vals[k]          = lloydMaxDequantize(data.config.numBitsPerDim,
-                                     kBitsPerInt,
-                                     data.config.stdDev,
-                                     p_turboRes[rqMemAddr],
-                                     embIdx);
+        vals[k] = lloydMaxDequantize(data.config.numBitsPerDim, kBitsPerInt, effStd, p_turboRes[rqMemAddr], embIdx);
     }
 
     // Step 2: WHT butterfly — inverse RHT = (1/sqrt(d)) * D * WHT(x_rot)
@@ -88,8 +86,7 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
     }
 
     // Step 3: sign flip, normalize, add centroid, store
-    int   centroidIdx = data.d_centroidIdx[docIdx];
-    float scale       = 1.0f / sqrtf((float)embDim);
+    float scale = 1.0f / sqrtf((float)embDim);
     for (int k = 0; k < elemsPerThread; k++)
     {
         int    embIdx          = threadIdx.x * elemsPerThread + k;

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -1,0 +1,79 @@
+#include "data.cuh"
+#include "methods_turbo_quant.cuh"
+#include "util.cuh"
+
+// One block per scored document, 1024 threads per block.
+// Each thread handles (embDim / 1024) elements cooperatively.
+// Shared memory layout: two ping-pong buffers of embDim floats for the WHT butterfly.
+__global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
+{
+    int toScoreIdx = blockIdx.x;
+    if (toScoreIdx >= data.config.numToScore)
+        return;
+
+    int docIdx         = data.d_docIdxToScore[toScoreIdx];
+    int embDim         = data.config.embDim;
+    int elemsPerThread = embDim / blockDim.x;
+
+    // Two ping-pong buffers for the in-place WHT butterfly
+    extern __shared__ float shm[]; // 2 * embDim floats
+    float*                  cur = shm;
+    float*                  nxt = shm + embDim;
+
+    // Step 1: Lloyd-Max dequantize into the rotated space
+    for (int k = 0; k < elemsPerThread; k++)
+    {
+        int    embIdx    = threadIdx.x * elemsPerThread + k;
+        int    rqIdx     = getRqIdx(embIdx, data.config.numBitsPerDim, kBitsPerInt);
+        size_t rqMemAddr = getMemAddr(docIdx, rqIdx, data.config.numDocs, data.config.getRqDim());
+        cur[embIdx]      = lloydMaxDequantize(data.config.numBitsPerDim,
+                                         kBitsPerInt,
+                                         data.config.stdDev,
+                                         p_turboRes[rqMemAddr],
+                                         embIdx);
+    }
+    __syncthreads();
+
+    // Step 2: Inverse RHT = (1/sqrt(d)) * D * WHT
+    // The forward RHT was: x_rot = (1/sqrt(d)) * WHT(D * x)
+    // The inverse is:      x     = (1/sqrt(d)) * D * WHT(x_rot)
+    // where D = diag(h_rhtSigns). Both forward and inverse have identical cost.
+
+    // WHT butterfly (ping-pong to avoid read-write conflicts)
+    for (int stride = 1; stride < embDim; stride <<= 1)
+    {
+        for (int k = 0; k < elemsPerThread; k++)
+        {
+            int   embIdx = threadIdx.x * elemsPerThread + k;
+            float a      = cur[embIdx];
+            float b      = cur[embIdx ^ stride];
+            nxt[embIdx]  = (embIdx & stride) ? (b - a) : (a + b);
+        }
+        __syncthreads();
+        float* tmp = cur;
+        cur        = nxt;
+        nxt        = tmp;
+    }
+
+    // Apply sign flip and normalize, then add centroid to recover the embedding
+    int   centroidIdx = data.d_centroidIdx[docIdx];
+    float scale       = 1.0f / sqrtf((float)embDim);
+    for (int k = 0; k < elemsPerThread; k++)
+    {
+        int    embIdx          = threadIdx.x * elemsPerThread + k;
+        float  residual        = cur[embIdx] * scale * data.d_rhtSigns[embIdx];
+        size_t centroidAddr    = getMemAddr(centroidIdx, embIdx * 2, data.config.numCentroids, data.config.embDim * 2);
+        float  centroid        = static_cast<float>(data.d_centroidEmb[centroidAddr]);
+        size_t dstMemAddr      = getMemAddr(toScoreIdx, embIdx, data.config.numToScore, data.config.embDim);
+        data.d_rst[dstMemAddr] = static_cast<EMB_T>(centroid + residual);
+    }
+}
+
+void methodTurboQuant(Data data, bool copyTurboResFromHost)
+{
+    RQ_T*  p_turboRes = copyTurboResFromHost ? data.h_turboRes : data.d_turboRes;
+    size_t shmBytes   = 2 * data.config.embDim * sizeof(float);
+    turboQuantKernel<<<data.config.numToScore, 1024, shmBytes>>>(data, p_turboRes);
+    CHECK_CUDA(cudaGetLastError());
+    CHECK_CUDA(cudaDeviceSynchronize());
+}

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -3,65 +3,104 @@
 #include "util.cuh"
 
 // One block per scored document, 1024 threads per block.
-// Each thread handles (embDim / 1024) elements cooperatively.
-// Shared memory layout: two ping-pong buffers of embDim floats for the WHT butterfly.
+// Each thread handles kElemsPerThread=4 elements (assumes embDim=4096).
+//
+// WHT butterfly is split into three tiers to minimize shared memory pressure:
+//   - Strides 1, 2        (< kElemsPerThread):     intra-thread, pure register ops
+//   - Strides 4 .. 64     (intra-warp):             __shfl_xor_sync, no shared memory
+//   - Strides 128 .. 2048 (inter-warp):             single shared memory buffer (16 KB)
+//
+// Using a single buffer (vs ping-pong) halves shared memory from 32 KB to 16 KB,
+// doubling occupancy from 4 to 8 blocks per SM.
 __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
 {
+    constexpr int kElemsPerThread = 4;
+
     int toScoreIdx = blockIdx.x;
     if (toScoreIdx >= data.config.numToScore)
         return;
 
-    int docIdx         = data.d_docIdxToScore[toScoreIdx];
-    int embDim         = data.config.embDim;
-    int elemsPerThread = embDim / blockDim.x;
+    int docIdx = data.d_docIdxToScore[toScoreIdx];
+    int embDim = data.config.embDim;
 
-    // Two ping-pong buffers for the in-place WHT butterfly
-    extern __shared__ float shm[]; // 2 * embDim floats
-    float*                  cur = shm;
-    float*                  nxt = shm + embDim;
-
-    // Step 1: Lloyd-Max dequantize into the rotated space
-    for (int k = 0; k < elemsPerThread; k++)
+    // Step 1: Lloyd-Max dequantize into registers (rotated space)
+    float vals[kElemsPerThread];
+    for (int k = 0; k < kElemsPerThread; k++)
     {
-        int    embIdx    = threadIdx.x * elemsPerThread + k;
+        int    embIdx    = threadIdx.x * kElemsPerThread + k;
         int    rqIdx     = getRqIdx(embIdx, data.config.numBitsPerDim, kBitsPerInt);
         size_t rqMemAddr = getMemAddr(docIdx, rqIdx, data.config.numDocs, data.config.getRqDim());
-        cur[embIdx]      = lloydMaxDequantize(data.config.numBitsPerDim,
-                                         kBitsPerInt,
-                                         data.config.stdDev,
-                                         p_turboRes[rqMemAddr],
-                                         embIdx);
+        vals[k]          = lloydMaxDequantize(data.config.numBitsPerDim,
+                                     kBitsPerInt,
+                                     data.config.stdDev,
+                                     p_turboRes[rqMemAddr],
+                                     embIdx);
     }
+
+    // Step 2: WHT butterfly — inverse RHT = (1/sqrt(d)) * D * WHT(x_rot)
+
+    // Tier 1: strides 1, 2 — pairs lie within the same thread's 4 elements, no sync needed
+    {
+        float a;
+        a       = vals[0];
+        vals[0] = a + vals[1];
+        vals[1] = a - vals[1];
+        a       = vals[2];
+        vals[2] = a + vals[3];
+        vals[3] = a - vals[3];
+        a       = vals[0];
+        vals[0] = a + vals[2];
+        vals[2] = a - vals[2];
+        a       = vals[1];
+        vals[1] = a + vals[3];
+        vals[3] = a - vals[3];
+    }
+
+    // Tier 2: strides 4..64 — pairs within the same warp, use warp shuffles
+    for (int stride = kElemsPerThread; stride < kElemsPerThread * 32; stride <<= 1)
+    {
+        int laneMask = stride / kElemsPerThread;
+        for (int k = 0; k < kElemsPerThread; k++)
+        {
+            int   globalIdx = threadIdx.x * kElemsPerThread + k;
+            float partner   = __shfl_xor_sync(0xffffffff, vals[k], laneMask);
+            vals[k]         = (globalIdx & stride) ? (partner - vals[k]) : (vals[k] + partner);
+        }
+    }
+
+    // Tier 3: strides 128..2048 — inter-warp, single shared memory buffer (16 KB)
+    extern __shared__ float shm[]; // embDim floats
+
+    for (int k = 0; k < kElemsPerThread; k++)
+        shm[threadIdx.x * kElemsPerThread + k] = vals[k];
     __syncthreads();
 
-    // Step 2: Inverse RHT = (1/sqrt(d)) * D * WHT
-    // The forward RHT was: x_rot = (1/sqrt(d)) * WHT(D * x)
-    // The inverse is:      x     = (1/sqrt(d)) * D * WHT(x_rot)
-    // where D = diag(h_rhtSigns). Both forward and inverse have identical cost.
-
-    // WHT butterfly (ping-pong to avoid read-write conflicts)
-    for (int stride = 1; stride < embDim; stride <<= 1)
+    for (int stride = kElemsPerThread * 32; stride < embDim; stride <<= 1)
     {
-        for (int k = 0; k < elemsPerThread; k++)
+        for (int k = 0; k < kElemsPerThread; k++)
         {
-            int   embIdx = threadIdx.x * elemsPerThread + k;
-            float a      = cur[embIdx];
-            float b      = cur[embIdx ^ stride];
-            nxt[embIdx]  = (embIdx & stride) ? (b - a) : (a + b);
+            int   globalIdx  = threadIdx.x * kElemsPerThread + k;
+            float localVal   = shm[globalIdx];
+            float partnerVal = shm[globalIdx ^ stride];
+            vals[k]          = (globalIdx & stride) ? (partnerVal - localVal) : (localVal + partnerVal);
         }
         __syncthreads();
-        float* tmp = cur;
-        cur        = nxt;
-        nxt        = tmp;
+        // Skip the write-back on the last stride — vals[] already holds the final result
+        if (stride < embDim / 2)
+        {
+            for (int k = 0; k < kElemsPerThread; k++)
+                shm[threadIdx.x * kElemsPerThread + k] = vals[k];
+            __syncthreads();
+        }
     }
 
-    // Apply sign flip and normalize, then add centroid to recover the embedding
+    // Step 3: sign flip, normalize, add centroid, store
     int   centroidIdx = data.d_centroidIdx[docIdx];
     float scale       = 1.0f / sqrtf((float)embDim);
-    for (int k = 0; k < elemsPerThread; k++)
+    for (int k = 0; k < kElemsPerThread; k++)
     {
-        int    embIdx          = threadIdx.x * elemsPerThread + k;
-        float  residual        = cur[embIdx] * scale * data.d_rhtSigns[embIdx];
+        int    embIdx          = threadIdx.x * kElemsPerThread + k;
+        float  residual        = vals[k] * scale * data.d_rhtSigns[embIdx];
         size_t centroidAddr    = getMemAddr(centroidIdx, embIdx * 2, data.config.numCentroids, data.config.embDim * 2);
         float  centroid        = static_cast<float>(data.d_centroidEmb[centroidAddr]);
         size_t dstMemAddr      = getMemAddr(toScoreIdx, embIdx, data.config.numToScore, data.config.embDim);
@@ -72,7 +111,7 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
 void methodTurboQuant(Data data, bool copyTurboResFromHost)
 {
     RQ_T*  p_turboRes = copyTurboResFromHost ? data.h_turboRes : data.d_turboRes;
-    size_t shmBytes   = 2 * data.config.embDim * sizeof(float);
+    size_t shmBytes   = data.config.embDim * sizeof(float); // single buffer, 16 KB for embDim=4096
     turboQuantKernel<<<data.config.numToScore, 1024, shmBytes>>>(data, p_turboRes);
     CHECK_CUDA(cudaGetLastError());
     CHECK_CUDA(cudaDeviceSynchronize());

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -101,8 +101,8 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
     {
         int    embIdx          = threadIdx.x * kElemsPerThread + k;
         float  residual        = vals[k] * scale * data.d_rhtSigns[embIdx];
-        size_t centroidAddr    = getMemAddr(centroidIdx, embIdx * 2, data.config.numCentroids, data.config.embDim * 2);
-        float  centroid        = static_cast<float>(data.d_centroidEmb[centroidAddr]);
+        size_t centroidAddr    = getMemAddr(centroidIdx, embIdx, data.config.numCentroids, data.config.embDim);
+        float  centroid        = static_cast<float>(data.d_centroidVal[centroidAddr]);
         size_t dstMemAddr      = getMemAddr(toScoreIdx, embIdx, data.config.numToScore, data.config.embDim);
         data.d_rst[dstMemAddr] = static_cast<EMB_T>(centroid + residual);
     }

--- a/embedding_quantization/src/methods_turbo_quant.cu
+++ b/embedding_quantization/src/methods_turbo_quant.cu
@@ -2,15 +2,20 @@
 #include "methods_turbo_quant.cuh"
 #include "util.cuh"
 
+// TurboQuant: https://arxiv.org/abs/2504.19874
+// Quantizes the raw embedding (no centroid subtraction) via RHT + Lloyd-Max.
+// RHT spreads energy uniformly across dims, making the distribution approximately
+// Gaussian and amenable to Lloyd-Max quantization.
+//
 // One block per scored document, 1024 threads per block.
 // elemsPerThread = embDim / 1024 (e.g. 1 for embDim=1024, 4 for embDim=4096).
 //
 // WHT butterfly is split into three tiers to minimize shared memory pressure:
-//   - Strides < elemsPerThread:                intra-thread, pure register ops
-//   - Strides elemsPerThread .. 16*elemsPerThread (intra-warp): __shfl_xor_sync
-//   - Strides 32*elemsPerThread .. embDim/2    (inter-warp):   single shared memory buffer
+//   - Strides < elemsPerThread:                   intra-thread, pure register ops
+//   - Strides elemsPerThread .. 31*elemsPerThread: __shfl_xor_sync (intra-warp)
+//   - Strides 32*elemsPerThread .. embDim/2:       single shared memory buffer
 //
-// Using a single buffer (vs ping-pong) halves shared memory, doubling occupancy.
+// Single buffer (vs ping-pong) halves shared memory, doubling occupancy.
 
 constexpr int kMaxElemsPerThread = 4; // upper bound; actual value is embDim / 1024
 
@@ -21,10 +26,9 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
         return;
 
     int   docIdx         = data.d_docIdxToScore[toScoreIdx];
-    int   centroidIdx    = data.d_centroidIdx[docIdx];
     int   embDim         = data.config.embDim;
     int   elemsPerThread = embDim / blockDim.x;
-    float effStd         = data.d_centroidEffStd[centroidIdx];
+    float stdDev         = data.turboQuantStdDev;
 
     // Step 1: Lloyd-Max dequantize into registers (rotated space)
     float vals[kMaxElemsPerThread];
@@ -33,10 +37,10 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
         int    embIdx    = threadIdx.x * elemsPerThread + k;
         int    rqIdx     = getRqIdx(embIdx, data.config.numBitsPerDim, kBitsPerInt);
         size_t rqMemAddr = getMemAddr(docIdx, rqIdx, data.config.numDocs, data.config.getRqDim());
-        vals[k] = lloydMaxDequantize(data.config.numBitsPerDim, kBitsPerInt, effStd, p_turboRes[rqMemAddr], embIdx);
+        vals[k] = lloydMaxDequantize(data.config.numBitsPerDim, kBitsPerInt, stdDev, p_turboRes[rqMemAddr], embIdx);
     }
 
-    // Step 2: WHT butterfly — inverse RHT = (1/sqrt(d)) * D * WHT(x_rot)
+    // Step 2: inverse RHT = (1/sqrt(d)) * D * WHT(x_rot)
 
     // Tier 1: strides 1..(elemsPerThread-1) — pairs within this thread's elements
     for (int stride = 1; stride < elemsPerThread; stride <<= 1)
@@ -48,7 +52,7 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
             vals[k] = (k & stride) ? (tmp[k ^ stride] - tmp[k]) : (tmp[k] + tmp[k ^ stride]);
     }
 
-    // Tier 2: strides elemsPerThread..16*elemsPerThread — intra-warp, use warp shuffles
+    // Tier 2: strides elemsPerThread..31*elemsPerThread — intra-warp, warp shuffles
     for (int stride = elemsPerThread; stride < elemsPerThread * 32; stride <<= 1)
     {
         int laneMask = stride / elemsPerThread;
@@ -85,16 +89,13 @@ __global__ void turboQuantKernel(Data data, RQ_T* p_turboRes)
         }
     }
 
-    // Step 3: sign flip, normalize, add centroid, store
+    // Step 3: sign flip + normalize → reconstructed embedding, store directly
     float scale = 1.0f / sqrtf((float)embDim);
     for (int k = 0; k < elemsPerThread; k++)
     {
         int    embIdx          = threadIdx.x * elemsPerThread + k;
-        float  residual        = vals[k] * scale * data.d_rhtSigns[embIdx];
-        size_t centroidAddr    = getMemAddr(centroidIdx, embIdx, data.config.numCentroids, data.config.embDim);
-        float  centroid        = static_cast<float>(data.d_centroidVal[centroidAddr]);
         size_t dstMemAddr      = getMemAddr(toScoreIdx, embIdx, data.config.numToScore, data.config.embDim);
-        data.d_rst[dstMemAddr] = static_cast<EMB_T>(centroid + residual);
+        data.d_rst[dstMemAddr] = static_cast<EMB_T>(vals[k] * scale * data.d_rhtSigns[embIdx]);
     }
 }
 

--- a/embedding_quantization/test/main.cu
+++ b/embedding_quantization/test/main.cu
@@ -81,9 +81,9 @@ int main()
     // -------------
     // Residual Quantization config
     Config config;
-    config.numDocs       = 1000000;
-    config.numToScore    = 100000;
-    config.embDim        = 4096;
+    config.numDocs       = 100000;
+    config.numToScore    = 10000;
+    config.embDim        = 1024;
     config.numBitsPerDim = 2;
     config.numCentroids  = 1024;
     config.stdDev        = 0.1f;

--- a/embedding_quantization/test/main.cu
+++ b/embedding_quantization/test/main.cu
@@ -82,7 +82,7 @@ int main()
     // Residual Quantization config
     Config config;
     config.numDocs       = 200000;
-    config.numToScore    = 10000;
+    config.numToScore    = 20000;
     config.embDim        = 4096;
     config.numBitsPerDim = 2;
     config.numCentroids  = 1024;

--- a/embedding_quantization/test/main.cu
+++ b/embedding_quantization/test/main.cu
@@ -105,6 +105,8 @@ int main()
     runExp(data, Method::BASELINE_D2D, "Baseline D2D", rstRef, kNumTrials);
     runExp(data, Method::RES_QUANT_H2D, "Residual Quant H2D", rstRef, kNumTrials);
     runExp(data, Method::RES_QUANT_D2D, "Residual Quant D2D", rstRef, kNumTrials);
+    runExp(data, Method::TURBO_QUANT_H2D, "Turbo Quant H2D", rstRef, kNumTrials);
+    runExp(data, Method::TURBO_QUANT_D2D, "Turbo Quant D2D", rstRef, kNumTrials);
 
     return 0;
 }

--- a/embedding_quantization/test/main.cu
+++ b/embedding_quantization/test/main.cu
@@ -81,9 +81,9 @@ int main()
     // -------------
     // Residual Quantization config
     Config config;
-    config.numDocs       = 100000;
+    config.numDocs       = 200000;
     config.numToScore    = 10000;
-    config.embDim        = 1024;
+    config.embDim        = 4096;
     config.numBitsPerDim = 2;
     config.numCentroids  = 1024;
     config.stdDev        = 0.1f;


### PR DESCRIPTION
## Summary

- Implements TurboQuant ([paper](https://arxiv.org/abs/2504.19874)): applies a Randomized Hadamard Transform (RHT) to the raw embedding before quantizing with a Lloyd-Max scalar quantizer. RHT spreads energy uniformly across dims, making the distribution approximately Gaussian and improving quantization efficiency.
- Optimizes the WHT CUDA kernel using a 3-tier butterfly (registers → warp shuffles → single shared memory buffer), halving shared memory vs ping-pong to double occupancy
- Fixes coalesced centroid memory access in ResQuant (flat `numCentroids × embDim` layout, was interleaved `embDim × 2`)
- ResQuant uses per-dim per-centroid stdDev for quantization boundaries (previously used a single global constant)

## Benchmark (NVIDIA T4, numDocs=200K, numToScore=20K, embDim=4096, numBitsPerDim=2, numCentroids=1024)

| Method         | RMSE  | Latency  |
|----------------|-------|----------|
| Baseline H2D   | 0.000 | 26.16 ms |
| Baseline D2D   | 0.000 |  2.42 ms |
| ResQuant H2D   | 0.106 |  9.36 ms |
| ResQuant D2D   | 0.106 |  5.90 ms |
| TurboQuant H2D | 0.343 | 19.03 ms |
| TurboQuant D2D | 0.343 | 13.29 ms |

Note: TurboQuant RMSE is higher than ResQuant because it quantizes the raw embedding directly (no centroid subtraction), matching the paper's design. ResQuant quantizes only the small residual around a centroid, which is an easier compression target.

## Test plan

- [ ] `./test_embedding_quantization_unit_tests` passes
- [ ] `./test_embedding_quantization` runs all 6 methods without error
- [ ] No illegal memory access for any embDim

🤖 Generated with [Claude Code](https://claude.com/claude-code)