### PR TITLE
Restructure cabm to include/src/test layout

### DIFF
--- a/cabm/CMakeLists.txt
+++ b/cabm/CMakeLists.txt
@@ -21,19 +21,8 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 find_package(CUDA REQUIRED)
 
 # Add library
-set(LIB_HEADER_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cabm.cuh
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_struct.cuh
-    ${CMAKE_CURRENT_SOURCE_DIR}/macro.cuh
-    ${CMAKE_CURRENT_SOURCE_DIR}/util.cuh
-)
-
-set(LIB_SOURCE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/cabm_common.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/cabm_cpu.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/cabm_gpu.cu
-    ${CMAKE_CURRENT_SOURCE_DIR}/data_struct.cu
-)
+file(GLOB_RECURSE LIB_HEADER_FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/*.cuh)
+file(GLOB_RECURSE LIB_SOURCE_FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu)
 
 add_library(${LIB_NAME} SHARED
     ${LIB_HEADER_FILES}
@@ -44,7 +33,7 @@ add_library(${LIB_NAME} SHARED
 set_property(TARGET ${LIB_NAME} PROPERTY CUDA_ARCHITECTURES 89)
 
 # Include directories
-target_include_directories(${LIB_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${LIB_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Link CUDA libraries
 target_link_libraries(${LIB_NAME} 
@@ -59,9 +48,9 @@ target_compile_options(${LIB_NAME} PRIVATE
 )
 
 # Add executable
-add_executable(test1 test1.cu)
-add_executable(test2 test2.cu)
-add_executable(test3 test3.cu)
+add_executable(test1 test/test1.cu)
+add_executable(test2 test/test2.cu)
+add_executable(test3 test/test3.cu)
 
 # Link library
 target_link_libraries(test1 ${LIB_NAME})

--- a/cabm/compile_commands.json
+++ b/cabm/compile_commands.json
@@ -1,1 +1,0 @@
-build/compile_commands.json

--- a/cabm/include/cabm.cuh
+++ b/cabm/include/cabm.cuh
@@ -7,17 +7,17 @@
 
 enum class CabmOpType
 {
-    LEFT_PARENTHESIS = 0,
+    LEFT_PARENTHESIS  = 0,
     RIGHT_PARENTHESIS = 1,
-    OPERATOR_AND = 2,
-    OPERATOR_OR = 3,
-    OPERAND_MATCH = 100,
+    OPERATOR_AND      = 2,
+    OPERATOR_OR       = 3,
+    OPERAND_MATCH     = 100,
 };
 
 class CabmOp
 {
 public:
-    CabmOp() = default; // Default constructor
+    CabmOp() = default;                                                              // Default constructor
     CabmOp(int reqFieldIdx, int docFieldIdx, CabmOpType type, bool negation = false) // Constructor for operands
         : m_reqFieldIdx(reqFieldIdx)
         , m_docFieldIdx(docFieldIdx)
@@ -31,40 +31,40 @@ public:
     }
 
     // Getters
-    __device__ __host__ int getReqFieldIdx() const { return m_reqFieldIdx; }
-    __device__ __host__ int getDocFieldIdx() const { return m_docFieldIdx; }
+    __device__ __host__ int        getReqFieldIdx() const { return m_reqFieldIdx; }
+    __device__ __host__ int        getDocFieldIdx() const { return m_docFieldIdx; }
     __device__ __host__ CabmOpType getOpType() const { return m_opType; }
 
     // Some convenient self-identifiers
     bool isOperand() const { return m_opType >= CabmOpType::OPERAND_MATCH; }
     bool isOperator() const { return m_opType < CabmOpType::OPERAND_MATCH && m_opType > CabmOpType::RIGHT_PARENTHESIS; }
     __device__ __host__ bool isNegation() const { return m_negation; }
-    bool isLeftParenthesis() const { return m_opType == CabmOpType::LEFT_PARENTHESIS; }
-    bool isRightParenthesis() const { return m_opType == CabmOpType::RIGHT_PARENTHESIS; }
+    bool                     isLeftParenthesis() const { return m_opType == CabmOpType::LEFT_PARENTHESIS; }
+    bool                     isRightParenthesis() const { return m_opType == CabmOpType::RIGHT_PARENTHESIS; }
 
     // Convert to string
     std::string toString() const;
 
 private:
-    int m_reqFieldIdx = -1; // Only used when op type is an operand
-    int m_docFieldIdx = -1; // Only used when op type is an operand
-    bool m_negation = false; // Only used when op type is an operand
-    CabmOpType m_opType; 
+    int        m_reqFieldIdx = -1;    // Only used when op type is an operand
+    int        m_docFieldIdx = -1;    // Only used when op type is an operand
+    bool       m_negation    = false; // Only used when op type is an operand
+    CabmOpType m_opType;
 };
 
 std::string cabmExprToString(const std::vector<CabmOp>& expr);
 
 std::vector<CabmOp> infix2postfix(std::vector<CabmOp> infix);
 
-bool evaluatePostfix(std::vector<CabmOp> postfix1D,
+bool evaluatePostfix(std::vector<CabmOp>                            postfix1D,
                      const std::vector<std::vector<ABM_DATA_TYPE>>& reqData2D,
                      const std::vector<std::vector<ABM_DATA_TYPE>>& docData2D);
 
-bool evaluatePostfixGpuWrapped(std::vector<CabmOp> postfix1D,
+bool evaluatePostfixGpuWrapped(std::vector<CabmOp>                            postfix1D,
                                const std::vector<std::vector<ABM_DATA_TYPE>>& reqData2D,
                                const std::vector<std::vector<ABM_DATA_TYPE>>& docData2D);
 
-std::vector<std::vector<uint8_t>> cabmCpu(const std::vector<CabmOp>& infixExpr,
+std::vector<std::vector<uint8_t>> cabmCpu(const std::vector<CabmOp>&                                  infixExpr,
                                           const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& reqData3D,
                                           const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& docData3D);
 
@@ -72,15 +72,15 @@ struct CabmGpuParam
 {
     std::vector<AbmDataGpu> reqAbmDataGpuList;
     std::vector<AbmDataGpu> docAbmDataGpuList;
-    std::vector<CabmOp> postfixOps;
-    uint64_t* d_bitStacks;
-    uint64_t numDocs;
-    uint64_t numReqs;
-    uint8_t* d_rst;
-    float timeMsOperandKernel = 0;
-    float timeMsOperatorKernel = 0;
-    float timeMsCopyRstKernel = 0;
-    float timeMsTotal = 0;
+    std::vector<CabmOp>     postfixOps;
+    uint64_t*               d_bitStacks;
+    uint64_t                numDocs;
+    uint64_t                numReqs;
+    uint8_t*                d_rst;
+    float                   timeMsOperandKernel  = 0;
+    float                   timeMsOperatorKernel = 0;
+    float                   timeMsCopyRstKernel  = 0;
+    float                   timeMsTotal          = 0;
 };
 
 void cabmGpu(CabmGpuParam& param);

--- a/cabm/include/data_struct.cuh
+++ b/cabm/include/data_struct.cuh
@@ -8,43 +8,37 @@ typedef int32_t ABM_DATA_TYPE;
 __device__ __host__ inline uint64_t getMemAddr(int row, int col, int numRows, int numCols)
 {
     return (uint64_t)row * numCols + col; // row-major
-    //return (uint64_t)col * numRows + row; // col-major
+    // return (uint64_t)col * numRows + row; // col-major
 }
 
 class AbmDataGpu
 {
 public:
     void init(const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& data3D,
-              int targetField,
-              bool useManagedMemory = false);
+              int                                                         targetField,
+              bool                                                        useManagedMemory = false);
 
     void free();
 
     // -----------------------
     // Getters
-    __device__ __host__ ABM_DATA_TYPE getVal(int row, int valIdx) const
-    {
-        return m_d_data[getMemAddrVal(row, valIdx)];
-    }
+    __device__ __host__ ABM_DATA_TYPE getVal(int row, int valIdx) const { return m_d_data[getMemAddrVal(row, valIdx)]; }
 
-    __device__ __host__ ABM_DATA_TYPE getNumVals(int row) const
-    {
-        return m_d_data[getMemAddrNumVals(row)];
-    }
+    __device__ __host__ ABM_DATA_TYPE getNumVals(int row) const { return m_d_data[getMemAddrNumVals(row)]; }
 
 private:
     // For example, let's say we have a 2D array like this:
-    //   [ 
+    //   [
     //      [7, 9],       // row 0, numVals = 2
     //      [13, 12, 15]  // row 1, numVals = 3
     //   ]
     // Assuming numValPerRow is 5, it will be stored as:
     //   m_d_data: [2, 7, 9, 0, 0, 0, 3, 13, 12, 15, 0, 0]
-    ABM_DATA_TYPE *m_d_data = nullptr;
-    uint64_t m_d_data_size = 0;
-    uint64_t m_d_data_size_in_bytes = 0;
+    ABM_DATA_TYPE* m_d_data               = nullptr;
+    uint64_t       m_d_data_size          = 0;
+    uint64_t       m_d_data_size_in_bytes = 0;
 
-    uint32_t m_numRows = 0;
+    uint32_t m_numRows          = 0;
     uint32_t m_maxNumValsPerRow = 0;
 
     __device__ __host__ uint64_t getMemAddrVal(int row, int valIdx) const
@@ -58,8 +52,8 @@ private:
     }
 };
 
-std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int numRows,
-                                                                   int numFields,
+std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int              numRows,
+                                                                   int              numFields,
                                                                    std::vector<int> numValsPerFieldMin,
                                                                    std::vector<int> numValsPerFieldMax,
                                                                    std::vector<int> cardinalities);

--- a/cabm/include/macro.cuh
+++ b/cabm/include/macro.cuh
@@ -6,7 +6,7 @@
         if (status != cudaSuccess)                                                                                     \
         {                                                                                                              \
             std::string error = "CUDA API failed at line " + std::to_string(__LINE__)                                  \
-                + " with error: " + cudaGetErrorString(status) + "\n";                                                 \
+                                + " with error: " + cudaGetErrorString(status) + "\n";                                 \
             throw std::runtime_error(error);                                                                           \
         }                                                                                                              \
     }

--- a/cabm/include/util.cuh
+++ b/cabm/include/util.cuh
@@ -1,23 +1,19 @@
 #pragma once
 
 #include <chrono>
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 class Timer
 {
 public:
-
-    void tic()
-    {
-        start_ = std::chrono::high_resolution_clock::now();
-    }
+    void tic() { start_ = std::chrono::high_resolution_clock::now(); }
 
     float tocMs()
     {
-        auto stop = std::chrono::high_resolution_clock::now();
+        auto                      stop     = std::chrono::high_resolution_clock::now();
         std::chrono::microseconds duration = std::chrono::duration_cast<std::chrono::microseconds>(stop - start_);
-        float timeMs = duration.count() / 1000.0;
+        float                     timeMs   = duration.count() / 1000.0;
         return timeMs;
     }
 
@@ -25,12 +21,11 @@ private:
     std::chrono::high_resolution_clock::time_point start_;
 };
 
-
 inline void printDeviceInfo()
 {
     using namespace std;
 
-    int deviceCount;
+    int         deviceCount;
     cudaError_t cudaError = cudaGetDeviceCount(&deviceCount);
     if (cudaError != cudaSuccess)
     {
@@ -48,8 +43,10 @@ inline void printDeviceInfo()
         cout << "  Total global memory: " << prop.totalGlobalMem / (1024 * 1024) << " MB" << endl;
         cout << "  Multiprocessor count: " << prop.multiProcessorCount << endl;
         cout << "  Max threads per block: " << prop.maxThreadsPerBlock << endl;
-        cout << "  Max threads dim: (" << prop.maxThreadsDim[0] << ", " << prop.maxThreadsDim[1] << ", " << prop.maxThreadsDim[2] << ")" << endl;
-        cout << "  Max grid size: (" << prop.maxGridSize[0] << ", " << prop.maxGridSize[1] << ", " << prop.maxGridSize[2] << ")" << endl;
+        cout << "  Max threads dim: (" << prop.maxThreadsDim[0] << ", " << prop.maxThreadsDim[1] << ", "
+             << prop.maxThreadsDim[2] << ")" << endl;
+        cout << "  Max grid size: (" << prop.maxGridSize[0] << ", " << prop.maxGridSize[1] << ", "
+             << prop.maxGridSize[2] << ")" << endl;
         cout << "  Clock rate: " << prop.clockRate / 1000 << " MHz" << endl;
         cout << "  Compute capability: " << prop.major << "." << prop.minor << endl;
         cout << "  Memory clock rate: " << prop.memoryClockRate / 1000 << " MHz" << endl;
@@ -63,6 +60,5 @@ inline void printDeviceInfo()
         cout << "  canMapHostMemory: " << (prop.canMapHostMemory ? "Yes" : "No") << endl;
         cout << "  sharedMemPerBlock: " << prop.sharedMemPerBlock / 1024 << " KB" << endl;
         cout << "  sharedMemPerMultiprocessor: " << prop.sharedMemPerMultiprocessor / 1024 << " KB" << endl;
-
     }
 }

--- a/cabm/run.sh
+++ b/cabm/run.sh
@@ -2,11 +2,13 @@
 
 set -e
 
-rm -rf build
+if [[ "$1" == "-a" ]]; then
+    rm -rf build
+fi
 mkdir -p build
 cd build
 cmake ..
-make -j 4
+make -j $(nproc)
 ./test1
 ./test2
 ./test3

--- a/cabm/src/cabm_common.cu
+++ b/cabm/src/cabm_common.cu
@@ -11,7 +11,7 @@
 namespace // anonymous namespace
 {
 
-    constexpr bool g_kDebug = false;
+constexpr bool g_kDebug = false;
 
 }
 
@@ -20,7 +20,7 @@ namespace // anonymous namespace
 std::vector<CabmOp> infix2postfix(std::vector<CabmOp> infix)
 {
     std::vector<CabmOp> postfix;
-    std::stack<CabmOp> s;
+    std::stack<CabmOp>  s;
 
     for (auto op : infix)
     {

--- a/cabm/src/cabm_cpu.cu
+++ b/cabm/src/cabm_cpu.cu
@@ -7,7 +7,7 @@
 #include "cabm.cuh"
 #include "data_struct.cuh"
 
-int evaluateOp(CabmOp& op,
+int evaluateOp(CabmOp&                                        op,
                const std::vector<std::vector<ABM_DATA_TYPE>>& reqData2D,
                const std::vector<std::vector<ABM_DATA_TYPE>>& docData2D)
 {
@@ -45,7 +45,7 @@ int evaluateOp(CabmOp& op,
 }
 
 // the code is modified from https://www.geeksforgeeks.org/evaluation-of-postfix-expression/
-bool evaluatePostfix(std::vector<CabmOp> postfix1D,
+bool evaluatePostfix(std::vector<CabmOp>                            postfix1D,
                      const std::vector<std::vector<ABM_DATA_TYPE>>& reqData2D,
                      const std::vector<std::vector<ABM_DATA_TYPE>>& docData2D)
 {
@@ -87,7 +87,7 @@ bool evaluatePostfix(std::vector<CabmOp> postfix1D,
     return (bool)st.top();
 }
 
-std::vector<std::vector<uint8_t>> cabmCpu(const std::vector<CabmOp>& infixExpr,
+std::vector<std::vector<uint8_t>> cabmCpu(const std::vector<CabmOp>&                                  infixExpr,
                                           const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& reqData3D,
                                           const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& docData3D)
 {

--- a/cabm/src/cabm_gpu.cu
+++ b/cabm/src/cabm_gpu.cu
@@ -24,8 +24,8 @@ constexpr uint32_t g_kMaxBitStackSize = 64;
 */
 __device__ void stackPush(uint64_t& bitStack, const uint8_t bitStackIdx, bool value)
 {
-    uint64_t mask = value? 1L << bitStackIdx : ~(1L << bitStackIdx);
-    bitStack = value? bitStack | mask : bitStack & mask;
+    uint64_t mask = value ? 1L << bitStackIdx : ~(1L << bitStackIdx);
+    bitStack      = value ? bitStack | mask : bitStack & mask;
 }
 
 /*
@@ -37,15 +37,15 @@ __device__ void stackPush(uint64_t& bitStack, const uint8_t bitStackIdx, bool va
 __device__ bool stackTop(const uint64_t bitStack, const uint8_t bitStackIdx)
 {
     uint64_t mask = 1L << bitStackIdx;
-    uint64_t tmp = bitStack & mask;
+    uint64_t tmp  = bitStack & mask;
     return tmp > 0L;
 }
 
 __device__ bool matchOp(const AbmDataGpu& reqAbmDataGpu,
                         const AbmDataGpu& docAbmDataGpu,
-                        const int reqIdx,
-                        const int docIdx,
-                        const CabmOp& op)
+                        const int         reqIdx,
+                        const int         docIdx,
+                        const CabmOp&     op)
 {
     // Init the value index
     int reqValIdx = 0;
@@ -91,11 +91,11 @@ struct OperandKernelParam
 {
     AbmDataGpu reqAbmDataGpu;
     AbmDataGpu docAbmDataGpu;
-    CabmOp op;
-    uint64_t reqIdx;
-    uint64_t numDocs;
-    uint64_t* d_bitStacks;
-    uint8_t bitStackIdx;
+    CabmOp     op;
+    uint64_t   reqIdx;
+    uint64_t   numDocs;
+    uint64_t*  d_bitStacks;
+    uint8_t    bitStackIdx;
 };
 
 __global__ void matchOpKernel(OperandKernelParam param)
@@ -110,11 +110,11 @@ __global__ void matchOpKernel(OperandKernelParam param)
 
 struct OperatorKernelParam
 {
-    CabmOp op;
-    uint64_t numPostfixOps;
+    CabmOp    op;
+    uint64_t  numPostfixOps;
     uint64_t* d_bitStacks;
-    uint64_t numDocs;
-    uint8_t bitStackIdx;
+    uint64_t  numDocs;
+    uint8_t   bitStackIdx;
 };
 
 __global__ void operatorKernel(OperatorKernelParam param)
@@ -123,9 +123,10 @@ __global__ void operatorKernel(OperatorKernelParam param)
     if (docIdx < param.numDocs)
     {
         uint64_t& bitStack = param.d_bitStacks[docIdx];
-        bool rst1 = stackTop(bitStack, param.bitStackIdx - 1); // Get the first of first operand
-        bool rst2 = stackTop(bitStack, param.bitStackIdx - 2); // Get the second of second operand
-        bool rst = (param.op.getOpType() == CabmOpType::OPERATOR_AND) ? (rst1 & rst2) : (rst1 | rst2); // Apply the operator
+        bool      rst1     = stackTop(bitStack, param.bitStackIdx - 1); // Get the first of first operand
+        bool      rst2     = stackTop(bitStack, param.bitStackIdx - 2); // Get the second of second operand
+        bool      rst
+            = (param.op.getOpType() == CabmOpType::OPERATOR_AND) ? (rst1 & rst2) : (rst1 | rst2); // Apply the operator
         stackPush(bitStack, param.bitStackIdx - 2, rst); // Push the result to the bit stack
     }
 }
@@ -143,10 +144,10 @@ void cabmGpu(CabmGpuParam& param)
 {
     // -----------------
     // Reset time
-    param.timeMsOperandKernel = 0;
+    param.timeMsOperandKernel  = 0;
     param.timeMsOperatorKernel = 0;
-    param.timeMsCopyRstKernel = 0;
-    param.timeMsTotal = 0;
+    param.timeMsCopyRstKernel  = 0;
+    param.timeMsTotal          = 0;
 
     // -----------------
     // Start timer
@@ -156,7 +157,7 @@ void cabmGpu(CabmGpuParam& param)
     // -----------------
     // Set the block and grid size
     const int kBlockSize = 1024;
-    const int kGridSize = (param.numDocs + kBlockSize - 1) / kBlockSize;
+    const int kGridSize  = (param.numDocs + kBlockSize - 1) / kBlockSize;
 
     for (uint32_t reqIdx = 0; reqIdx < param.numReqs; reqIdx++)
     {
@@ -164,7 +165,7 @@ void cabmGpu(CabmGpuParam& param)
         // Initialize the bit stack index and set the bit stack to 0
         uint8_t currBitStackIdx = 0;
         CHECK_CUDA(cudaMemset(param.d_bitStacks, 0, param.numDocs * sizeof(uint64_t)));
-        
+
         for (const auto& op : param.postfixOps)
         {
             if (op.isOperand())
@@ -184,11 +185,11 @@ void cabmGpu(CabmGpuParam& param)
                 OperandKernelParam operandKernelParam;
                 operandKernelParam.reqAbmDataGpu = param.reqAbmDataGpuList.at(op.getReqFieldIdx());
                 operandKernelParam.docAbmDataGpu = param.docAbmDataGpuList.at(op.getDocFieldIdx());
-                operandKernelParam.op = op;
-                operandKernelParam.reqIdx = reqIdx;
-                operandKernelParam.numDocs = param.numDocs;
-                operandKernelParam.d_bitStacks = param.d_bitStacks;
-                operandKernelParam.bitStackIdx = currBitStackIdx;
+                operandKernelParam.op            = op;
+                operandKernelParam.reqIdx        = reqIdx;
+                operandKernelParam.numDocs       = param.numDocs;
+                operandKernelParam.d_bitStacks   = param.d_bitStacks;
+                operandKernelParam.bitStackIdx   = currBitStackIdx;
 
                 // -----------------
                 // Launch the operand kernel
@@ -218,10 +219,10 @@ void cabmGpu(CabmGpuParam& param)
                 // -----------------
                 // Create the operator kernel parameter
                 OperatorKernelParam operatorKernelParam;
-                operatorKernelParam.op = op;
+                operatorKernelParam.op          = op;
                 operatorKernelParam.d_bitStacks = param.d_bitStacks;
                 operatorKernelParam.bitStackIdx = currBitStackIdx;
-                operatorKernelParam.numDocs = param.numDocs;
+                operatorKernelParam.numDocs     = param.numDocs;
 
                 // -----------------
                 // Launch the operator kernel
@@ -263,7 +264,7 @@ void cabmGpu(CabmGpuParam& param)
     param.timeMsTotal = timerTotal.tocMs();
 }
 
-bool evaluatePostfixGpuWrapped(std::vector<CabmOp> postfix1D,
+bool evaluatePostfixGpuWrapped(std::vector<CabmOp>                            postfix1D,
                                const std::vector<std::vector<ABM_DATA_TYPE>>& reqData2D,
                                const std::vector<std::vector<ABM_DATA_TYPE>>& docData2D)
 {
@@ -273,8 +274,8 @@ bool evaluatePostfixGpuWrapped(std::vector<CabmOp> postfix1D,
     {
         reqAbmDataGpuList.push_back(AbmDataGpu());
         docAbmDataGpuList.push_back(AbmDataGpu());
-        reqAbmDataGpuList.at(field).init({reqData2D}, field, true);
-        docAbmDataGpuList.at(field).init({docData2D}, field, true);
+        reqAbmDataGpuList.at(field).init({ reqData2D }, field, true);
+        docAbmDataGpuList.at(field).init({ docData2D }, field, true);
     }
 
     uint8_t* d_rst;
@@ -283,11 +284,11 @@ bool evaluatePostfixGpuWrapped(std::vector<CabmOp> postfix1D,
     CHECK_CUDA(cudaMallocManaged(&d_bitStacks, 1 * sizeof(uint64_t)));
 
     CabmGpuParam param;
-    param.d_rst = d_rst;
-    param.d_bitStacks = d_bitStacks;
-    param.numDocs = 1;
-    param.numReqs = 1;
-    param.postfixOps = postfix1D;
+    param.d_rst             = d_rst;
+    param.d_bitStacks       = d_bitStacks;
+    param.numDocs           = 1;
+    param.numReqs           = 1;
+    param.postfixOps        = postfix1D;
     param.reqAbmDataGpuList = reqAbmDataGpuList;
     param.docAbmDataGpuList = docAbmDataGpuList;
 

--- a/cabm/src/data_struct.cu
+++ b/cabm/src/data_struct.cu
@@ -1,12 +1,12 @@
-#include <stdexcept>
-#include <random>
 #include <algorithm>
+#include <random>
+#include <stdexcept>
 
 #include "data_struct.cuh"
 
 void AbmDataGpu::init(const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>& data3D,
-                              int targetField,
-                              bool useManagedMemory)
+                      int                                                         targetField,
+                      bool                                                        useManagedMemory)
 {
     // -----------------
     // Check empty and infer num rows
@@ -26,7 +26,7 @@ void AbmDataGpu::init(const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>
         for (const auto& inputData2D : data3D)
         {
             const auto& inputData1D = inputData2D.at(targetField);
-            m_maxNumValsPerRow = std::max(m_maxNumValsPerRow, (uint32_t)inputData1D.size());
+            m_maxNumValsPerRow      = std::max(m_maxNumValsPerRow, (uint32_t)inputData1D.size());
             data2D.push_back(inputData1D);
         }
         m_maxNumValsPerRow++; // The first element is reserved for storing num vals per row
@@ -35,10 +35,10 @@ void AbmDataGpu::init(const std::vector<std::vector<std::vector<ABM_DATA_TYPE>>>
 
     // -----------------
     // Malloc data
-    {   
+    {
         // -----------
         // Calculate the size of the data
-        m_d_data_size = m_numRows * m_maxNumValsPerRow;
+        m_d_data_size          = m_numRows * m_maxNumValsPerRow;
         m_d_data_size_in_bytes = m_d_data_size * sizeof(ABM_DATA_TYPE);
 
         // -----------
@@ -94,14 +94,14 @@ void AbmDataGpu::free()
         cudaFree(m_d_data);
         m_d_data = nullptr;
     }
-    m_d_data_size = 0;
+    m_d_data_size          = 0;
     m_d_data_size_in_bytes = 0;
-    m_numRows = 0;
-    m_maxNumValsPerRow = 0;
+    m_numRows              = 0;
+    m_maxNumValsPerRow     = 0;
 }
 
-std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int numRows,
-                                                                   int numFields,
+std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int              numRows,
+                                                                   int              numFields,
                                                                    std::vector<int> numValsPerFieldMin,
                                                                    std::vector<int> numValsPerFieldMax,
                                                                    std::vector<int> cardinalities)
@@ -119,7 +119,7 @@ std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int numRows,
 
     // -----------------
     // Prepare random number generator
-    std::default_random_engine generator(std::random_device{}());
+    std::default_random_engine                   generator(std::random_device {}());
     std::uniform_int_distribution<ABM_DATA_TYPE> valDist;
 
     // -----------------
@@ -130,9 +130,9 @@ std::vector<std::vector<std::vector<ABM_DATA_TYPE>>> genRandData3D(int numRows,
         std::vector<std::vector<ABM_DATA_TYPE>> data2D;
         for (int field = 0; field < numFields; field++)
         {
-            std::vector<ABM_DATA_TYPE> data1D;
+            std::vector<ABM_DATA_TYPE>         data1D;
             std::uniform_int_distribution<int> numValsDist(numValsPerFieldMin.at(field), numValsPerFieldMax.at(field));
-            int numVals = numValsDist(generator);
+            int                                numVals = numValsDist(generator);
             for (int val = 0; val < numVals; val++)
             {
                 data1D.push_back(valDist(generator) % cardinalities.at(field));

--- a/cabm/test/test1.cu
+++ b/cabm/test/test1.cu
@@ -34,12 +34,13 @@ void test1a()
 
     std::cout << "Postfix: " << cabmExprToString(postfix) << std::endl;
 
-    assert(cabmExprToString(postfix) == "{R0 MATCH D0} {R1 MATCH D1} OR {NOT R3 MATCH D3} {R4 MATCH D4} OR {R5 MATCH D5} AND AND");
+    assert(cabmExprToString(postfix)
+           == "{R0 MATCH D0} {R1 MATCH D1} OR {NOT R3 MATCH D3} {R4 MATCH D4} OR {R5 MATCH D5} AND AND");
 
     {
         std::vector<std::vector<ABM_DATA_TYPE>> reqTbr2D = { { 0 }, { 1 }, { 2 }, { -3 }, { 4 }, { 5 } };
         std::vector<std::vector<ABM_DATA_TYPE>> docTbr2D = { { 0 }, { -1 }, { -2 }, { 3 }, { -4 }, { 5 } };
-        bool rstCpu = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
+        bool                                    rstCpu   = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
         std::cout << "test1a_1, cpu rst: " << rstCpu << std::endl;
         assert(rstCpu == true);
 
@@ -51,7 +52,7 @@ void test1a()
     {
         std::vector<std::vector<ABM_DATA_TYPE>> reqTbr2D = { { 0 }, { 1 }, { 2 }, { -3 }, { 4 }, { -5 } };
         std::vector<std::vector<ABM_DATA_TYPE>> docTbr2D = { { 0 }, { -1 }, { -2 }, { 3 }, { -4 }, { 5 } };
-        bool rstCpu = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
+        bool                                    rstCpu   = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
         std::cout << "test1a_2, cpu rst: " << rstCpu << std::endl;
         assert(rstCpu == false);
 
@@ -64,18 +65,15 @@ void test1a()
 void test1b()
 {
     // infix = (F0 OR F1) AND ( (F3 OR F4) AND F5 )
-    std::vector<CabmOp> infix = {
-        CabmOp(CabmOpType::LEFT_PARENTHESIS),
-        CabmOp(0, 0, CabmOpType::OPERAND_MATCH),
-        CabmOp(CabmOpType::OPERATOR_OR),
-        CabmOp(1, 1, CabmOpType::OPERAND_MATCH),
-        CabmOp(CabmOpType::RIGHT_PARENTHESIS)
-    };
+    std::vector<CabmOp> infix = { CabmOp(CabmOpType::LEFT_PARENTHESIS),
+                                  CabmOp(0, 0, CabmOpType::OPERAND_MATCH),
+                                  CabmOp(CabmOpType::OPERATOR_OR),
+                                  CabmOp(1, 1, CabmOpType::OPERAND_MATCH),
+                                  CabmOp(CabmOpType::RIGHT_PARENTHESIS) };
 
     std::cout << "Infix: " << cabmExprToString(infix) << std::endl;
 
-    assert(cabmExprToString(infix)
-           == "( {R0 MATCH D0} OR {R1 MATCH D1} )");
+    assert(cabmExprToString(infix) == "( {R0 MATCH D0} OR {R1 MATCH D1} )");
 
     std::vector<CabmOp> postfix = infix2postfix(infix);
 
@@ -86,7 +84,7 @@ void test1b()
     {
         std::vector<std::vector<ABM_DATA_TYPE>> reqTbr2D = { { 0 }, { 1 } };
         std::vector<std::vector<ABM_DATA_TYPE>> docTbr2D = { { 0 }, { 1 } };
-        bool rst = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
+        bool                                    rst      = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
         assert(rst == true);
 
         bool rstGpu = evaluatePostfixGpuWrapped(postfix, reqTbr2D, docTbr2D);
@@ -99,23 +97,17 @@ void test1c()
 {
     // infix = (F0 OR F1) AND ( (F3 OR F4) AND F5 )
     std::vector<CabmOp> infix = {
-        CabmOp(CabmOpType::LEFT_PARENTHESIS),
-        CabmOp(0, 0, CabmOpType::OPERAND_MATCH),
-        CabmOp(CabmOpType::OPERATOR_OR),
-        CabmOp(1, 1, CabmOpType::OPERAND_MATCH),
-        CabmOp(CabmOpType::RIGHT_PARENTHESIS),
-        CabmOp(CabmOpType::OPERATOR_AND),
-        CabmOp(CabmOpType::LEFT_PARENTHESIS),
-        CabmOp(3, 3, CabmOpType::OPERAND_MATCH, true),
-        CabmOp(CabmOpType::OPERATOR_OR),
-        CabmOp(4, 4, CabmOpType::OPERAND_MATCH),
+        CabmOp(CabmOpType::LEFT_PARENTHESIS),  CabmOp(0, 0, CabmOpType::OPERAND_MATCH),
+        CabmOp(CabmOpType::OPERATOR_OR),       CabmOp(1, 1, CabmOpType::OPERAND_MATCH),
+        CabmOp(CabmOpType::RIGHT_PARENTHESIS), CabmOp(CabmOpType::OPERATOR_AND),
+        CabmOp(CabmOpType::LEFT_PARENTHESIS),  CabmOp(3, 3, CabmOpType::OPERAND_MATCH, true),
+        CabmOp(CabmOpType::OPERATOR_OR),       CabmOp(4, 4, CabmOpType::OPERAND_MATCH),
         CabmOp(CabmOpType::RIGHT_PARENTHESIS),
     };
 
     std::cout << "Infix: " << cabmExprToString(infix) << std::endl;
 
-    assert(cabmExprToString(infix)
-           == "( {R0 MATCH D0} OR {R1 MATCH D1} ) AND ( {NOT R3 MATCH D3} OR {R4 MATCH D4} )");
+    assert(cabmExprToString(infix) == "( {R0 MATCH D0} OR {R1 MATCH D1} ) AND ( {NOT R3 MATCH D3} OR {R4 MATCH D4} )");
 
     std::vector<CabmOp> postfix = infix2postfix(infix);
 
@@ -124,9 +116,9 @@ void test1c()
     assert(cabmExprToString(postfix) == "{R0 MATCH D0} {R1 MATCH D1} OR {NOT R3 MATCH D3} {R4 MATCH D4} OR AND");
 
     {
-        std::vector<std::vector<ABM_DATA_TYPE>> reqTbr2D = { { 0 }, { 1 }, {2}, { -3 }, { 4 } };
-        std::vector<std::vector<ABM_DATA_TYPE>> docTbr2D = { { 0 }, { -1 }, {2}, { 3 }, { -4 } };
-        bool rstCpu = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
+        std::vector<std::vector<ABM_DATA_TYPE>> reqTbr2D = { { 0 }, { 1 }, { 2 }, { -3 }, { 4 } };
+        std::vector<std::vector<ABM_DATA_TYPE>> docTbr2D = { { 0 }, { -1 }, { 2 }, { 3 }, { -4 } };
+        bool                                    rstCpu   = evaluatePostfix(postfix, reqTbr2D, docTbr2D);
         std::cout << "test1c, cpu rst: " << rstCpu << std::endl;
         assert(rstCpu == true);
 

--- a/cabm/test/test2.cu
+++ b/cabm/test/test2.cu
@@ -6,11 +6,11 @@
 
 void test2a()
 {
-    int numRows = 10;
-    int numFields = 3;
+    int              numRows            = 10;
+    int              numFields          = 3;
     std::vector<int> numValsPerFieldMin = { 1, 2, 3 };
     std::vector<int> numValsPerFieldMax = { 10, 20, 30 };
-    std::vector<int> cardinalities = { 100, 100, 100 };
+    std::vector<int> cardinalities      = { 100, 100, 100 };
 
     const auto data3D = genRandData3D(numRows, numFields, numValsPerFieldMin, numValsPerFieldMax, cardinalities);
 
@@ -30,7 +30,9 @@ void test2a()
         {
             if (reqAbmDataGpuList.at(field).getNumVals(row) != data3D.at(row).at(field).size())
             {
-                std::cout << "Error at (" << row << ", " << field << "): " << reqAbmDataGpuList.at(field).getNumVals(row) << " != " << data3D.at(row).at(field).size() << std::endl;
+                std::cout << "Error at (" << row << ", " << field
+                          << "): " << reqAbmDataGpuList.at(field).getNumVals(row)
+                          << " != " << data3D.at(row).at(field).size() << std::endl;
                 assert(false);
             }
             for (uint32_t valOffset = 0; valOffset < data3D.at(row).at(field).size(); valOffset++)
@@ -38,7 +40,8 @@ void test2a()
                 ABM_DATA_TYPE val = reqAbmDataGpuList.at(field).getVal(row, valOffset);
                 if (val != data3D.at(row).at(field).at(valOffset))
                 {
-                    std::cout << "Error at (" << row << ", " << field << ", " << valOffset << "): " << val << " != " << data3D.at(row).at(field).at(valOffset) << std::endl;
+                    std::cout << "Error at (" << row << ", " << field << ", " << valOffset << "): " << val
+                              << " != " << data3D.at(row).at(field).at(valOffset) << std::endl;
                     assert(false);
                 }
             }

--- a/cabm/test/test3.cu
+++ b/cabm/test/test3.cu
@@ -3,20 +3,20 @@
 #include <iostream>
 #include <vector>
 
-#include "data_struct.cuh"
 #include "cabm.cuh"
+#include "data_struct.cuh"
 #include "macro.cuh"
 #include "util.cuh"
 
 void test3a()
 {
-    const int kNumReqs = 1;
-    const uint64_t kNumDocs = 1000000;
-    const int kNumFields = 6;
-    const int kNumTrials = 100;
+    const int              kNumReqs            = 1;
+    const uint64_t         kNumDocs            = 1000000;
+    const int              kNumFields          = 6;
+    const int              kNumTrials          = 100;
     const std::vector<int> kNumValsPerFieldMin = { 2, 2, 2, 2, 2, 2 };
     const std::vector<int> kNumValsPerFieldMax = { 10, 10, 10, 10, 10, 10 };
-    const std::vector<int> kCardinalities = { 100, 100, 100, 100, 100, 100 };
+    const std::vector<int> kCardinalities      = { 100, 100, 100, 100, 100, 100 };
 
     const auto reqData3D
         = genRandData3D(kNumReqs, kNumFields, kNumValsPerFieldMin, kNumValsPerFieldMax, kCardinalities);
@@ -53,8 +53,8 @@ void test3a()
         {
             reqAbmDataGpuList.push_back(AbmDataGpu());
             docAbmDataGpuList.push_back(AbmDataGpu());
-            reqAbmDataGpuList.at(fieldIdx).init({reqData3D}, fieldIdx, true);
-            docAbmDataGpuList.at(fieldIdx).init({docData3D}, fieldIdx, true);
+            reqAbmDataGpuList.at(fieldIdx).init({ reqData3D }, fieldIdx, true);
+            docAbmDataGpuList.at(fieldIdx).init({ docData3D }, fieldIdx, true);
         }
 
         uint8_t* d_rst;
@@ -63,20 +63,20 @@ void test3a()
         CHECK_CUDA(cudaMalloc(&d_bitStacks, kNumDocs * sizeof(uint64_t)));
 
         CabmGpuParam param;
-        param.d_rst = d_rst;
-        param.d_bitStacks = d_bitStacks;
-        param.numDocs = kNumDocs;
-        param.numReqs = kNumReqs;
-        param.postfixOps = postfix;
+        param.d_rst             = d_rst;
+        param.d_bitStacks       = d_bitStacks;
+        param.numDocs           = kNumDocs;
+        param.numReqs           = kNumReqs;
+        param.postfixOps        = postfix;
         param.reqAbmDataGpuList = reqAbmDataGpuList;
         param.docAbmDataGpuList = docAbmDataGpuList;
 
         Timer timer;
-        float timeMsOperandKernel = 0;
+        float timeMsOperandKernel  = 0;
         float timeMsOperatorKernel = 0;
-        float timeMsCopyRstKernel = 0;
-        float timeMsTotal = 0;
-        float timeMsTotalOuter = 0;
+        float timeMsCopyRstKernel  = 0;
+        float timeMsTotal          = 0;
+        float timeMsTotalOuter     = 0;
         for (int trial = -3; trial < kNumTrials; trial++)
         {
             if (trial == 0)
@@ -139,8 +139,8 @@ void test3a()
                     {
                         numCFGT++;
                     }
-                    //std::cout << "Error at (" << reqIdx << ", " << docIdx << "): " << rstCpu << " != " << rstGpu << std::endl;
-                    //assert(false);
+                    // std::cout << "Error at (" << reqIdx << ", " << docIdx << "): " << rstCpu << " != " << rstGpu <<
+                    // std::endl; assert(false);
                 }
             }
         }


### PR DESCRIPTION
Restructures `cabm` to mirror the directory layout used in `concurrent_read_write_paradigm`:

- Headers (`*.cuh`) moved into `include/`
- Implementation (`*.cu`) moved into `src/`
- Test executables moved into `test/`
- `CMakeLists.txt` switched to `file(GLOB_RECURSE ...)` discovery with `include/` as a `PUBLIC` include directory
- `run.sh` updated to support an `-a` flag (full rebuild) and use `nproc` for parallel jobs
- Removed the stray tracked `compile_commands.json` (now regenerated under the gitignored `build/` dir)

Verified locally: `bash cabm/run.sh` configures and builds `libcabm.so`, `test1`, `test2`, `test3` successfully. Test execution aborts only because this sandbox has no CUDA-capable GPU (`cudaMalloc failed: no CUDA-capable device is detected`), unrelated to the restructuring.